### PR TITLE
feat(acp): add Codex agent support and seren-acp sidecar binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,22 @@
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "4"
   },
+  "sidecars": {
+    "seren-acp-claude": {
+      "name": "Claude Code",
+      "git": "https://github.com/serenorg/seren-acp-claude",
+      "tag": "v0.1.0",
+      "bin": "seren-acp-claude",
+      "dest": "seren-acp-claude"
+    },
+    "seren-acp-codex": {
+      "name": "Codex",
+      "git": "https://github.com/serenorg/seren-acp-codex",
+      "tag": "v0.1.0",
+      "bin": "seren-acp-codex",
+      "dest": "seren-acp-codex"
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
     "@hey-api/openapi-ts": "0.90.10",


### PR DESCRIPTION
## Summary
- Port Codex agent integration from seren-desktop to seren-local runtime
- Replace legacy `acp_agent` binary naming with `seren-acp-claude` / `seren-acp-codex` sidecar naming (matching desktop)
- Dynamic availability detection for both Claude and Codex agents in `acpGetAvailableAgents`
- Add `sidecars` manifest to `package.json` defining agent binary sources
- Backwards compatible: still finds legacy `acp_agent` binary for Claude

## Test plan
- [ ] Verify Claude agent spawns correctly with existing `acp_agent` binary
- [ ] Verify Claude agent spawns with new `seren-acp-claude` binary name
- [ ] Verify Codex agent spawns when `seren-acp-codex` binary is present
- [ ] Verify agent selector UI shows both agents with correct availability status

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com