### PR TITLE
feat: port desktop fixes to seren-local

### DIFF
--- a/src/components/chat/ThinkingStatus.tsx
+++ b/src/components/chat/ThinkingStatus.tsx
@@ -34,8 +34,12 @@ export function ThinkingStatus() {
   onCleanup(() => clearInterval(timer));
 
   return (
-    <span class="inline-flex items-center gap-2 text-sm text-[#8b949e]">
-      <span class="inline-block w-2 h-2 rounded-full bg-[#58a6ff] animate-pulse" />
+    <span class="inline-flex items-center gap-2 text-sm text-[#e6edf3]">
+      <span class="inline-flex items-center gap-[3px]">
+        <span class="inline-block w-1.5 h-1.5 rounded-full bg-[#58a6ff]" style="animation: bounce-dot 1.4s ease-in-out infinite" />
+        <span class="inline-block w-1.5 h-1.5 rounded-full bg-[#58a6ff]" style="animation: bounce-dot 1.4s ease-in-out 0.2s infinite" />
+        <span class="inline-block w-1.5 h-1.5 rounded-full bg-[#58a6ff]" style="animation: bounce-dot 1.4s ease-in-out 0.4s infinite" />
+      </span>
       <span>{THINKING_WORDS[index()]}…</span>
     </span>
   );

--- a/src/services/catalog.ts
+++ b/src/services/catalog.ts
@@ -196,6 +196,21 @@ export function formatNumber(num: number): string {
  * Publisher catalog service for Seren API operations.
  * Uses generated SDK with full type safety.
  */
+/**
+ * Extract a human-readable message from an SDK error object.
+ */
+function formatApiError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null) {
+    const obj = error as Record<string, unknown>;
+    if (typeof obj.message === "string") return obj.message;
+    if (typeof obj.detail === "string") return obj.detail;
+    if (typeof obj.error === "string") return obj.error;
+    if (typeof obj.status === "number") return `HTTP ${obj.status}`;
+  }
+  return String(error);
+}
+
 export const catalog = {
   /**
    * List all active publishers.
@@ -208,7 +223,7 @@ export const catalog = {
     });
     if (error) {
       console.error("[Catalog] Error fetching publishers:", error);
-      throw new Error("Failed to list publishers");
+      throw new Error(`Failed to list publishers: ${formatApiError(error)}`);
     }
     const rawPublishers = data?.data || [];
     console.log("[Catalog] Found", rawPublishers.length, "publishers");
@@ -224,7 +239,7 @@ export const catalog = {
       throwOnError: false,
     });
     if (error || !data?.data) {
-      throw new Error("Failed to get publisher");
+      throw new Error(`Failed to get publisher: ${formatApiError(error)}`);
     }
     return transformPublisher(data.data);
   },
@@ -242,7 +257,7 @@ export const catalog = {
       throwOnError: false,
     });
     if (error) {
-      throw new Error("Failed to search publishers");
+      throw new Error(`Failed to search publishers: ${formatApiError(error)}`);
     }
     const rawPublishers = data?.data || [];
     return rawPublishers.map(transformPublisher);
@@ -300,7 +315,7 @@ export const catalog = {
       throwOnError: false,
     });
     if (error) {
-      throw new Error("Failed to list publishers by category");
+      throw new Error(`Failed to list publishers by category: ${formatApiError(error)}`);
     }
     const rawPublishers = data?.data || [];
     return rawPublishers.map(transformPublisher);

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -23,7 +23,7 @@ import type { Message } from "@/services/chat";
 import { sendMessage } from "@/services/chat";
 
 const DEFAULT_MODEL = "anthropic/claude-opus-4.5";
-const MAX_MESSAGES_PER_CONVERSATION = 100;
+const MAX_MESSAGES_PER_CONVERSATION = 1000;
 
 /**
  * A compacted summary of older messages.

--- a/src/styles.css
+++ b/src/styles.css
@@ -235,3 +235,15 @@ code {
     opacity: 0.5;
   }
 }
+
+/* Bouncing dot animation for thinking indicator */
+@keyframes bounce-dot {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+  }
+  40% {
+    transform: translateY(-4px);
+  }
+}


### PR DESCRIPTION
## Summary
- **Truncate large tool results** at 50KB with smart JSON array summarization (extracts key fields from first 25 items)
- **Raise max messages** per conversation from 100 to 1000
- **3-dot bounce thinking animation** replacing single pulsing dot, with brighter text
- **Surface actual API error details** in catalog publisher listing errors via `formatApiError()` helper
- **Structured logging** for permission request/response flow and cancel prompt flow

Ported from seren-desktop commits: `34de44e`, `b487be0`, `71d119e`, `241fb42`, `f15bb75`

4 other desktop fixes were already present in seren-local: MouseEvent fix, dead session guard, await session ready, agent type picker.

## Test plan
- [ ] Start an agent session and verify the 3-dot bounce animation appears while thinking
- [ ] Trigger a tool call that returns large results and verify truncation
- [ ] Check catalog error messages include actual API error details
- [ ] Verify permission request logging appears in console during agent tool approval

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com