### PR TITLE
feat: port desktop updates batch 4

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -237,6 +237,8 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   });
 
   const handleCancel = async () => {
+    // Clear queued messages so they don't auto-send after cancellation
+    setMessageQueue([]);
     await acpStore.cancelPrompt();
   };
 

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Shared authentication error detection patterns.
+// ABOUTME: Used by acp.store and AgentChat to identify auth failures vs normal content.
+
+/** Patterns that indicate an authentication/session error. */
+const AUTH_ERROR_PATTERNS = [
+  /login required/i,
+  /claude login/i,
+  /not logged in/i,
+  /authentication_error/i,
+  /authentication expired/i,
+  /oauth token has expired/i,
+  /token has expired/i,
+  /token expired/i,
+  /session expired/i,
+  /invalid.*token/i,
+  /expired.*token/i,
+  /unauthorized/i,
+  /please obtain a new token/i,
+  /refresh your existing token/i,
+  /please sign in/i,
+  /does not have access/i,
+  /please login again/i,
+];
+
+/**
+ * Max length of a genuine auth error message. Real auth errors from CLI tools
+ * are short (< 500 chars). Longer messages are normal assistant responses that
+ * happen to contain auth-related phrases in tool output or code discussion.
+ */
+const AUTH_ERROR_MAX_LENGTH = 500;
+
+/**
+ * Check if an error message indicates an authentication/session failure.
+ * Use for messages already known to be errors (error events, session errors).
+ */
+export function isAuthError(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  return AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(msg));
+}
+
+/**
+ * Stricter check for auth errors in streamed assistant content.
+ * Real auth errors from CLI tools are short messages. Long assistant
+ * responses that mention "token expired" in tool output or code
+ * discussion should not trigger the auth error banner.
+ */
+export function isLikelyAuthError(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  if (msg.length > AUTH_ERROR_MAX_LENGTH) return false;
+  return AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(msg));
+}

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -547,7 +547,12 @@ export const acpStore = {
         return;
       }
 
-      this.addErrorMessage(sessionId, message);
+      // Skip addErrorMessage for cancellation — the error event handler
+      // already recorded it in chat history. Adding it again here would
+      // create a duplicate banner.
+      if (!message.includes("Task cancelled")) {
+        this.addErrorMessage(sessionId, message);
+      }
     }
   },
 
@@ -770,7 +775,26 @@ export const acpStore = {
         break;
 
       case "error":
-        this.addErrorMessage(sessionId, event.data.error);
+        // Clean up any in-flight streaming and tool cards
+        this.finalizeStreamingContent(sessionId);
+        this.markPendingToolCallsComplete(sessionId);
+
+        if (String(event.data.error).includes("Task cancelled")) {
+          // User-initiated cancellation: record in chat history but don't
+          // show the persistent error banner (it's not a real error).
+          const cancelMsg: AgentMessage = {
+            id: crypto.randomUUID(),
+            type: "error",
+            content: event.data.error,
+            timestamp: Date.now(),
+          };
+          setState("sessions", sessionId, "messages", (msgs) => [
+            ...msgs,
+            cancelMsg,
+          ]);
+        } else {
+          this.addErrorMessage(sessionId, event.data.error);
+        }
         break;
 
       case "permissionRequest": {
@@ -974,6 +998,42 @@ export const acpStore = {
 
     setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
     setState("sessions", sessionId, "error", error);
+  },
+
+  /**
+   * Mark any pending/running tool call cards as completed.
+   * Called on cancellation and error to stop spinners.
+   */
+  markPendingToolCallsComplete(sessionId: string) {
+    const session = state.sessions[sessionId];
+    if (!session) return;
+
+    const runningStatuses = ["running", "pending", "in_progress"];
+    const hasRunning = session.messages.some(
+      (msg) =>
+        msg.toolCall &&
+        runningStatuses.includes(msg.toolCall.status.toLowerCase()),
+    );
+
+    if (!hasRunning) return;
+
+    setState("sessions", sessionId, "messages", (msgs) =>
+      msgs.map((msg) => {
+        if (
+          msg.toolCall &&
+          runningStatuses.includes(msg.toolCall.status.toLowerCase())
+        ) {
+          return {
+            ...msg,
+            toolCall: { ...msg.toolCall, status: "completed" },
+          };
+        }
+        return msg;
+      }),
+    );
+
+    // Clear pending map
+    session.pendingToolCalls.clear();
   },
 
   // ============================================================================


### PR DESCRIPTION
## Summary
- **Cancel dedup fix**: Clear message queue on cancel to prevent queued messages from auto-sending after cancellation. Skip duplicate error banners for 'Task cancelled' — the error event handler records it in chat history without the persistent error banner since it's user-initiated, not a real error.
- **Tool card cleanup**: Add `markPendingToolCallsComplete()` method to stop tool card spinners on cancellation/errors. Call `finalizeStreamingContent()` on error events to flush any in-flight streaming content.
- **Shared auth-errors.ts**: Centralized `AUTH_ERROR_PATTERNS` with `isAuthError()` and length-guarded `isLikelyAuthError()` to prevent false positive auth banners when agents discuss auth topics in normal output.

## Files changed (3)
- `src/components/chat/AgentChat.tsx` — clear message queue in handleCancel
- `src/stores/acp.store.ts` — cancel dedup in sendPrompt catch + error event handler, markPendingToolCallsComplete
- `src/lib/auth-errors.ts` — new shared auth error detection with length guard

## Test plan
- [ ] Cancel an active agent session — verify no duplicate error banners appear
- [ ] Cancel while messages are queued — verify queued messages don't send after cancel
- [ ] Cancel while tool cards are spinning — verify spinners stop
- [ ] Build succeeds: `npm run build`

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com