### PR TITLE
feat: port desktop updates batch 6 — streaming perf, markdown, MCP

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -22,7 +22,11 @@ import { openExternalLink } from "@/lib/external-link";
 import { formatDurationWithVerb } from "@/lib/format-duration";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
-import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
+import {
+  escapeHtmlWithLinks,
+  renderMarkdown,
+  renderMarkdownStreaming,
+} from "@/lib/render-markdown";
 import type { AgentType, DiffEvent } from "@/services/acp";
 import { type AgentMessage, acpStore } from "@/stores/acp.store";
 import { fileTreeState } from "@/stores/fileTree";
@@ -54,6 +58,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const [isAttaching, setIsAttaching] = createSignal(false);
   let inputRef: HTMLTextAreaElement | undefined;
   let messagesRef: HTMLDivElement | undefined;
+  let userHasScrolledUp = false;
 
   // Build reversed list of user prompts for Up/Down arrow navigation
   const userMessageHistory = createMemo(() =>
@@ -85,6 +90,29 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     }
   });
 
+  // Throttled streaming markdown: renders at most every 80 ms to avoid
+  // saturating the main thread with O(n) marked.parse calls on every chunk.
+  const [streamingMarkdown, setStreamingMarkdown] = createSignal("");
+  let streamingThrottle: ReturnType<typeof setTimeout> | null = null;
+  createEffect(() => {
+    const content = acpStore.streamingContent;
+    if (streamingThrottle !== null) clearTimeout(streamingThrottle);
+    if (!content) {
+      setStreamingMarkdown("");
+      return;
+    }
+    streamingThrottle = setTimeout(() => {
+      streamingThrottle = null;
+      setStreamingMarkdown(renderMarkdownStreaming(content));
+    }, 80);
+    onCleanup(() => {
+      if (streamingThrottle !== null) {
+        clearTimeout(streamingThrottle);
+        streamingThrottle = null;
+      }
+    });
+  });
+
   const hasSession = () => acpStore.activeSession !== null;
   const isReady = () => acpStore.activeSession?.info.status === "ready";
   const isPrompting = () => acpStore.activeSession?.info.status === "prompting";
@@ -98,20 +126,22 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const hasFolderOpen = () => Boolean(fileTreeState.rootPath);
 
   const scrollToBottom = () => {
-    if (messagesRef) {
+    if (messagesRef && !userHasScrolledUp) {
       messagesRef.scrollTop = messagesRef.scrollHeight;
     }
   };
 
+  const handleMessagesScroll = () => {
+    if (!messagesRef) return;
+    const { scrollTop, scrollHeight, clientHeight } = messagesRef;
+    // Consider "near bottom" within 80px
+    userHasScrolledUp = scrollHeight - scrollTop - clientHeight > 80;
+  };
+
   // Auto-scroll when messages change
   createEffect(() => {
-    const messages = acpStore.messages;
-    const streaming = acpStore.streamingContent;
-    console.log("[AgentChat] Effect triggered:", {
-      messagesCount: messages.length,
-      streamingLength: streaming.length,
-      streamingPreview: streaming.slice(0, 100),
-    });
+    acpStore.messages;
+    acpStore.streamingContent;
     requestAnimationFrame(scrollToBottom);
   });
 
@@ -221,6 +251,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
     setInput("");
     setAttachedImages([]);
+    userHasScrolledUp = false;
     await acpStore.sendPrompt(trimmed, context);
   };
 
@@ -418,6 +449,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
       {/* Messages Area */}
       <div
         ref={messagesRef}
+        onScroll={handleMessagesScroll}
         class="flex-1 min-h-0 overflow-y-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-[#30363d] [&::-webkit-scrollbar-thumb]:rounded"
         onClick={(e) => {
           const target = e.target as HTMLElement;
@@ -561,10 +593,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             {/* Streaming Content */}
             <Show when={acpStore.streamingContent}>
               <article class="px-5 py-4 border-b border-[#21262d]">
-                <div class="text-sm leading-relaxed text-[#e6edf3] whitespace-pre-wrap">
-                  {acpStore.streamingContent}
-                  <span class="inline-block w-2 h-4 ml-0.5 bg-[#58a6ff] animate-pulse" />
-                </div>
+                <div
+                  class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-xl [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-lg [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-2 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-2 [&_h4]:mb-1 [&_code]:bg-[#21262d] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline"
+                  innerHTML={streamingMarkdown()}
+                />
+                <span class="inline-block w-2 h-4 ml-0.5 bg-[#58a6ff] animate-pulse" />
               </article>
             </Show>
           </Show>

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -88,11 +88,11 @@ function createMcpClient() {
         env: env || null,
       });
 
-      // Fetch tools and resources
-      const [tools, resources] = await Promise.all([
-        listTools(serverName),
-        listResources(serverName),
-      ]);
+      // Fetch tools (always) and resources (only if server announced capability)
+      const tools = await listTools(serverName);
+      const resources = result.capabilities?.resources
+        ? await listResources(serverName)
+        : [];
 
       // Update connection state
       setConnections((prev) => {

--- a/src/lib/render-markdown.ts
+++ b/src/lib/render-markdown.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Converts markdown text to HTML for display in agent chat messages.
+// ABOUTME: Handles code highlighting, link safety, and agent unfenced-code normalization.
 import hljs from "highlight.js";
 import { marked, type Tokens } from "marked";
 import { escapeHtml } from "@/lib/escape-html";
@@ -58,8 +60,142 @@ marked.setOptions({
   renderer,
 });
 
+/**
+ * Returns true when a line (already trimmed) looks like TypeScript/JavaScript
+ * code rather than prose. Used by wrapCodeIslands to detect unfenced code.
+ */
+export function isCodeLine(trimmed: string, inCComment: boolean): boolean {
+  if (!trimmed) return false;
+
+  // C-style comment openers (/** or /*)
+  if (/^\/\*\*?/.test(trimmed)) return true;
+
+  // C-style comment closers and continuations – only inside an open comment
+  if (inCComment && /^(\*\/|\*\s)/.test(trimmed)) return true;
+
+  // TypeScript/JS typed declarations
+  if (/^(export\s+)?(type|interface)\s+\w/.test(trimmed)) return true;
+  if (/^(export\s+)?(abstract\s+)?class\s+\w/.test(trimmed)) return true;
+  if (/^(export\s+)?(async\s+)?function\s+\w/.test(trimmed)) return true;
+  if (/^(export\s+)?(const|let|var)\s+[\w_$]/.test(trimmed)) return true;
+  if (/^(export\s+)?enum\s+\w/.test(trimmed)) return true;
+  if (/^import\s+(type\s+)?(\{|\*|[\w_$])/.test(trimmed)) return true;
+
+  // Lines ending with ; — strong code signal. Exclude obvious prose sentences
+  if (/;\s*$/.test(trimmed) && !/^[A-Z][a-z]+\s+[a-z]/.test(trimmed))
+    return true;
+
+  // Closing brace/bracket lines common in TypeScript
+  if (/^\}[;,]?\s*$/.test(trimmed)) return true;
+
+  // HTTP/OpenAPI status-code type entries: `404: unknown;`
+  if (/^\d{3,4}:\s+\w/.test(trimmed)) return true;
+
+  return false;
+}
+
+/**
+ * Wrap consecutive "code island" lines outside existing fences in a
+ * ```typescript fence. Agents frequently output TypeScript type definitions
+ * and JSDoc comments as plain text without code fences, causing * lines to
+ * render as markdown bullets and declarations to appear as unstyled paragraphs.
+ *
+ * A run of 2+ consecutive code-like lines is wrapped. Single isolated lines
+ * are left alone to avoid false positives.
+ */
+export function wrapCodeIslands(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let inFence = false;
+  let inCComment = false;
+  const codeBuf: string[] = [];
+  const blankBuf: string[] = [];
+
+  const flush = () => {
+    if (codeBuf.length >= 2) {
+      while (codeBuf.length > 0 && !codeBuf[codeBuf.length - 1].trim()) {
+        blankBuf.unshift(codeBuf.pop() as string);
+      }
+      if (codeBuf.length >= 2) {
+        out.push("```typescript", ...codeBuf, "```");
+        codeBuf.length = 0;
+        return;
+      }
+    }
+    out.push(...codeBuf);
+    codeBuf.length = 0;
+  };
+
+  for (const line of lines) {
+    const t = line.trim();
+
+    if (/^(`{3,}|~{3,})/.test(t)) {
+      if (!inFence) {
+        flush();
+        out.push(...blankBuf);
+        blankBuf.length = 0;
+      }
+      inFence = !inFence;
+      out.push(line);
+      continue;
+    }
+
+    if (inFence) {
+      out.push(line);
+      continue;
+    }
+
+    if (!t) {
+      blankBuf.push(line);
+      continue;
+    }
+
+    if (/\/\*\*?/.test(t)) inCComment = true;
+
+    if (isCodeLine(t, inCComment)) {
+      codeBuf.push(...blankBuf, line);
+      blankBuf.length = 0;
+    } else {
+      flush();
+      out.push(...blankBuf, line);
+      blankBuf.length = 0;
+    }
+
+    if (/\*\//.test(t)) inCComment = false;
+  }
+
+  flush();
+  out.push(...blankBuf);
+  return out.join("\n");
+}
+
+/**
+ * Ensure ATX headings and fenced code blocks are preceded by a blank line.
+ * Also detects unfenced TypeScript/JSDoc "code islands" and wraps them in
+ * fenced code blocks so they render with syntax highlighting.
+ */
+function normalizeAgentMarkdown(markdown: string): string {
+  let result = markdown.replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2");
+  result = result.replace(/([^\n])\n(`{3,}|~{3,})/g, "$1\n\n$2");
+  return wrapCodeIslands(result);
+}
+
 export function renderMarkdown(markdown: string): string {
-  const result = marked.parse(markdown);
+  const result = marked.parse(normalizeAgentMarkdown(markdown));
+  return typeof result === "string" ? result : "";
+}
+
+// Fast path for streaming: skip wrapCodeIslands (expensive O(n) scan per chunk).
+// Called on every throttle tick during active streaming; wrapCodeIslands runs
+// once when the final message is committed to messages.
+function normalizeStreaming(markdown: string): string {
+  let result = markdown.replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2");
+  result = result.replace(/([^\n])\n(`{3,}|~{3,})/g, "$1\n\n$2");
+  return result;
+}
+
+export function renderMarkdownStreaming(markdown: string): string {
+  const result = marked.parse(normalizeStreaming(markdown));
   return typeof result === "string" ? result : "";
 }
 


### PR DESCRIPTION
## Summary
- Port streaming performance, markdown rendering, and MCP client fixes from seren-desktop
- **P3 — Streaming perf**: throttled 80ms markdown rendering, normalizeAgentMarkdown preprocessor, wrapCodeIslands for unfenced TypeScript/JSDoc, scroll preservation when user scrolls up, streaming content now renders as HTML markdown instead of plain text
- **P5 — MCP fix**: skip resources/list for servers without resources capability (prevents Promise.all rejection from discarding tools)

## Desktop commits ported
| Hash | Description |
|------|-------------|
| `67f66b0e` | Normalize agent markdown — blank lines before headings/fences |
| `fc4b3927` | Wrap unfenced TypeScript/JSDoc output in code fences |
| `752811ca` | Throttle streaming render to 80ms, add renderMarkdownStreaming |
| `5bf69956` | Preserve scroll position when user scrolls up during streaming |
| `98070354` | Skip resources/list for MCP servers without resources capability |

## Test plan
- [ ] Send a prompt — streaming content should render as formatted markdown (headings, code blocks, etc.)
- [ ] Scroll up during streaming — position should be preserved, not snapped to bottom
- [ ] Send a new message — should auto-scroll to bottom again
- [ ] Check DevTools console — no per-chunk debug logs
- [ ] Connect an MCP server that only has tools (no resources) — should connect without error

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com