### PR TITLE
feat: port desktop updates batch 7 — UI polish, output collapsing

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -16,8 +16,10 @@ import { AcpPermissionDialog } from "@/components/acp/AcpPermissionDialog";
 import { DiffProposalDialog } from "@/components/acp/DiffProposalDialog";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
+import { collapseBuildOutput } from "@/lib/build-output";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
+import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
 import { formatDurationWithVerb } from "@/lib/format-duration";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
@@ -340,6 +342,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         const newIndex = Math.min(historyIndex() + 1, history.length - 1);
         setHistoryIndex(newIndex);
         setInput(history[newIndex]);
+        queueMicrotask(() => {
+          textarea.setSelectionRange(
+            textarea.value.length,
+            textarea.value.length,
+          );
+        });
         return;
       }
     }
@@ -356,6 +364,12 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
         } else {
           setInput(history[newIndex]);
         }
+        queueMicrotask(() => {
+          textarea.setSelectionRange(
+            textarea.value.length,
+            textarea.value.length,
+          );
+        });
         return;
       }
     }
@@ -386,7 +400,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article class="px-5 py-4 border-b border-[#21262d]">
             <div
               class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_code]:bg-[#21262d] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline"
-              innerHTML={renderMarkdown(message.content)}
+              innerHTML={collapseBuildOutput(
+                collapseDirectoryListings(
+                  renderMarkdown(message.content),
+                ),
+              )}
             />
             <Show when={durationDisplay}>
               <div class="mt-2 text-xs text-[#8b949e]">
@@ -644,9 +662,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
 
       {/* Error Display */}
       <Show when={sessionError()}>
-        <div class="mx-4 mb-2 px-3 py-2 bg-[rgba(248,81,73,0.1)] border border-[rgba(248,81,73,0.4)] rounded-md text-sm text-[#f85149] flex items-center justify-between">
-          <span>{sessionError()}</span>
-          <div class="flex items-center gap-2">
+        <div class="mx-4 mb-2 px-3 py-2 bg-[rgba(248,81,73,0.1)] border border-[rgba(248,81,73,0.4)] rounded-md text-sm text-[#f85149] flex items-start justify-between gap-2">
+          <span class="flex-1 max-h-28 overflow-y-auto break-words">{sessionError()}</span>
+          <div class="flex items-center gap-2 shrink-0">
             <Show when={acpStore.activeSession?.info.status === "error"}>
               <button
                 type="button"

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -14,8 +14,10 @@ import {
 } from "solid-js";
 import { SignIn } from "@/components/auth/SignIn";
 import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
+import { collapseBuildOutput } from "@/lib/build-output";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
+import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
 import { pickAndReadImages } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
@@ -758,7 +760,11 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                           class="chat-message-content text-[14px] leading-[1.7] text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-[1.3em] [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:text-[#f0f6fc] [&_h1]:border-b [&_h1]:border-[#21262d] [&_h1]:pb-2 [&_h2]:text-[1.15em] [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-[#f0f6fc] [&_h3]:text-[1.05em] [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-2 [&_h3]:text-[#f0f6fc] [&_code]:bg-[#1c2333] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_li]:leading-[1.6] [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline [&_strong]:text-[#f0f6fc] [&_strong]:font-semibold"
                           innerHTML={
                             message.role === "assistant"
-                              ? renderMarkdown(message.content)
+                              ? collapseBuildOutput(
+                                  collapseDirectoryListings(
+                                    renderMarkdown(message.content),
+                                  ),
+                                )
                               : escapeHtmlWithLinks(message.content)
                           }
                         />
@@ -925,7 +931,6 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                         setCommandPopupIndex(0);
                         if (historyIndex() !== -1) {
                           setHistoryIndex(-1);
-                          setSavedInput("");
                         }
                       }}
                       onKeyDown={(event) => {
@@ -993,6 +998,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                             );
                             setHistoryIndex(newIndex);
                             setInput(history[newIndex]);
+                            queueMicrotask(() => {
+                              textarea.setSelectionRange(
+                                textarea.value.length,
+                                textarea.value.length,
+                              );
+                            });
                           }
                         }
 
@@ -1013,6 +1024,12 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                             } else {
                               setInput(history[newIndex]);
                             }
+                            queueMicrotask(() => {
+                              textarea.setSelectionRange(
+                                textarea.value.length,
+                                textarea.value.length,
+                              );
+                            });
                           }
                         }
 

--- a/src/lib/build-output.ts
+++ b/src/lib/build-output.ts
@@ -1,0 +1,115 @@
+// ABOUTME: Detects verbose build/compile output and provides collapse utilities.
+// ABOUTME: Used to suppress noisy cargo/npm/pip output in chat and agent chat panels.
+
+/**
+ * Patterns that match a single line of verbose build output.
+ * Each regex should match common package-manager progress lines.
+ */
+const BUILD_LINE_PATTERNS = [
+  // Cargo (Rust)
+  /^\s*(Compiling|Downloading|Downloaded|Locking|Updating|Fetching|Unpacking|Fresh)\s+\S+/,
+  // npm / pnpm / yarn
+  /^\s*(added|removed|updated|npm warn|npm info|packages in)\s/i,
+  // pip (Python)
+  /^\s*(Collecting|Downloading|Installing|Using cached|Requirement already satisfied)\s/i,
+  // Go
+  /^\s*go: (downloading|extracting|finding)\s/,
+];
+
+/** Minimum consecutive matching lines to trigger detection */
+const MIN_CONSECUTIVE = 5;
+
+/**
+ * Returns true if the text is predominantly verbose build output.
+ */
+export function isBuildOutput(text: string): boolean {
+  const lines = text.split("\n");
+  let consecutive = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (BUILD_LINE_PATTERNS.some((p) => p.test(trimmed))) {
+      consecutive++;
+      if (consecutive >= MIN_CONSECUTIVE) return true;
+    } else {
+      consecutive = 0;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns a one-line summary of build output.
+ * Counts matching lines and identifies the build tool.
+ */
+export function summarizeBuildOutput(text: string): string {
+  const lines = text.split("\n");
+  let count = 0;
+  let tool = "Build";
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (BUILD_LINE_PATTERNS.some((p) => p.test(trimmed))) {
+      count++;
+      if (/^\s*Compiling\s/.test(trimmed)) tool = "Cargo build";
+      else if (/^\s*Downloading\s/.test(trimmed) && tool === "Build")
+        tool = "Download";
+      else if (/^\s*(added|npm)\s/i.test(trimmed)) tool = "npm install";
+      else if (/^\s*(Collecting|pip)\s/i.test(trimmed)) tool = "pip install";
+      else if (/^\s*go:\s/.test(trimmed)) tool = "Go build";
+    }
+  }
+  return `${tool} output (${count} ${count === 1 ? "line" : "lines"})`;
+}
+
+/** Decode basic HTML entities for detection in rendered HTML. */
+function decodeBasicHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Post-processes rendered HTML to collapse verbose build output blocks.
+ * Wraps detected blocks in native <details><summary> elements.
+ */
+export function collapseBuildOutput(html: string): string {
+  // Handle build output inside <pre><code> blocks (markdown-rendered path)
+  const modified = html.replace(
+    /(<pre[^>]*><code[^>]*>)([\s\S]*?)(<\/code><\/pre>)/g,
+    (match, _open: string, content: string, _close: string) => {
+      const decoded = decodeBasicHtmlEntities(content);
+      if (isBuildOutput(decoded)) {
+        const summary = summarizeBuildOutput(decoded);
+        return `<details class="build-output-collapse"><summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>${match}</details>`;
+      }
+      return match;
+    },
+  );
+
+  // If we already handled a <pre> block, return
+  if (modified !== html) return modified;
+
+  // Handle <br>-separated content (fallback/escaped HTML path)
+  if (!/<pre[\s>]/.test(html)) {
+    const segments = html.split(/<br\s*\/?>/i);
+    if (segments.length >= MIN_CONSECUTIVE) {
+      const plainText = segments
+        .map((s) => decodeBasicHtmlEntities(s))
+        .join("\n");
+      if (isBuildOutput(plainText)) {
+        const summary = summarizeBuildOutput(plainText);
+        return [
+          '<details class="build-output-collapse">',
+          `<summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>`,
+          `<pre style="white-space:pre-wrap;margin:0.5em 0;font-size:12px;color:inherit">${html}</pre>`,
+          "</details>",
+        ].join("");
+      }
+    }
+  }
+
+  return html;
+}

--- a/src/lib/directory-listing.ts
+++ b/src/lib/directory-listing.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Detects Unix directory listing output and provides collapse utilities.
+// ABOUTME: Used to suppress verbose ls output in chat and agent chat panels.
+
+/** Unix ls -l permission format: drwxr-xr-x, -rw-r--r--, etc. */
+const LS_LINE = /^[dlcbps-][rwxsStT-]{9}\s/;
+
+/** Total line header from ls -l output */
+const TOTAL_LINE = /^total \d+$/;
+
+/** Minimum consecutive matching lines to trigger detection */
+const MIN_CONSECUTIVE = 5;
+
+/**
+ * Returns true if the text is predominantly a Unix directory listing.
+ * Detects `ls -l` style output with permission bits.
+ */
+export function isDirectoryListing(text: string): boolean {
+  const lines = text.split("\n");
+  let consecutive = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (LS_LINE.test(trimmed) || TOTAL_LINE.test(trimmed)) {
+      consecutive++;
+      if (consecutive >= MIN_CONSECUTIVE) return true;
+    } else {
+      consecutive = 0;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns a one-line summary of a directory listing.
+ * Counts lines matching ls -l format.
+ */
+export function summarizeDirectoryListing(text: string): string {
+  const lines = text.split("\n");
+  let count = 0;
+  for (const line of lines) {
+    if (LS_LINE.test(line.trim())) count++;
+  }
+  return `Directory listing (${count} ${count === 1 ? "entry" : "entries"})`;
+}
+
+/** Decode basic HTML entities for detection in rendered HTML. */
+function decodeBasicHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Post-processes rendered HTML to collapse directory listing blocks.
+ * Wraps detected blocks in native <details><summary> elements.
+ */
+export function collapseDirectoryListings(html: string): string {
+  // Handle directory listings inside <pre><code> blocks (markdown-rendered path)
+  const modified = html.replace(
+    /(<pre[^>]*><code[^>]*>)([\s\S]*?)(<\/code><\/pre>)/g,
+    (match, _open: string, content: string, _close: string) => {
+      const decoded = decodeBasicHtmlEntities(content);
+      if (isDirectoryListing(decoded)) {
+        const summary = summarizeDirectoryListing(decoded);
+        return `<details class="dir-listing-collapse"><summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>${match}</details>`;
+      }
+      return match;
+    },
+  );
+
+  // If we already handled a <pre> block, return
+  if (modified !== html) return modified;
+
+  // Handle <br>-separated content (fallback/escaped HTML path)
+  if (!/<pre[\s>]/.test(html)) {
+    const segments = html.split(/<br\s*\/?>/i);
+    if (segments.length >= MIN_CONSECUTIVE) {
+      const plainText = segments
+        .map((s) => decodeBasicHtmlEntities(s))
+        .join("\n");
+      if (isDirectoryListing(plainText)) {
+        const summary = summarizeDirectoryListing(plainText);
+        return [
+          '<details class="dir-listing-collapse">',
+          `<summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>`,
+          `<pre style="white-space:pre-wrap;margin:0.5em 0;font-size:12px;color:inherit">${html}</pre>`,
+          "</details>",
+        ].join("");
+      }
+    }
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary
- **Draft text preservation**: cursor now positions at end of text after Up/Down arrow history navigation via `queueMicrotask`, and `setSavedInput` no longer clears draft on accidental keystrokes (AgentChat + ChatContent)
- **Error banner height cap**: large error messages no longer push the input box off-screen (`max-h-28` + `overflow-y-auto`, action buttons pinned with `shrink-0`)
- **Directory listing collapse**: new `lib/directory-listing.ts` auto-detects `ls -l` output (5+ consecutive permission-string lines) and wraps in collapsible `<details>` summary
- **Build output collapse**: new `lib/build-output.ts` auto-detects verbose cargo/npm/pip/go build output and wraps in collapsible summary
- Both collapse utilities integrated into AgentChat and ChatContent rendering pipelines

## Desktop commits ported
- `364ac3fb` — preserve draft text during history navigation
- `ea884106` — cap error banner height (CSS portion only; acp.store.ts part was in batch 5)
- `73a7ccf1` — collapse directory listing output
- `4fe14304` — collapse verbose build output

## Skipped
- `bb856ea3` (prompt-too-long auto-failover) — depends on `isPromptTooLongError`/`acceptRateLimitFallback` infrastructure not present in seren-local

## Test plan
- [ ] Verify Up/Down arrow history navigation positions cursor at end of text
- [ ] Verify draft text is preserved when accidentally typing during history browse
- [ ] Trigger a large error and confirm banner is capped at ~112px with scroll
- [ ] Send a message containing `ls -l` output (5+ lines) and verify it collapses
- [ ] Send a message containing cargo/npm build output and verify it collapses
- [ ] Verify normal messages render unchanged

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com