### PR TITLE
feat: rate limit and prompt-too-long auto-failover to Chat mode

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -21,6 +21,10 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
+import {
+  getModelDisplayName,
+  mapAgentModelToChat,
+} from "@/lib/rate-limit-fallback";
 import { formatDurationWithVerb } from "@/lib/format-duration";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
@@ -690,6 +694,54 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
             </button>
           </div>
         </div>
+      </Show>
+
+      {/* Agent Fallback Banner (rate limit or context window full) */}
+      <Show when={acpStore.agentFallbackNeeded}>
+        {(() => {
+          const agentType =
+            acpStore.activeSession?.info.agentType ?? "claude-code";
+          const chatModelId = mapAgentModelToChat(undefined, agentType);
+          const modelName = getModelDisplayName(chatModelId);
+          const agentName = agentType === "codex" ? "Codex" : "Claude Code";
+          const reason = acpStore.agentFallbackReason;
+          const title =
+            reason === "prompt_too_long"
+              ? `${agentName}'s context window is full`
+              : `${agentName} hit its rate limit`;
+          const description = `Automatically switching to Chat mode with ${modelName}. Your conversation history will be preserved.`;
+          return (
+            <div class="mx-4 mb-2 px-3 py-3 border rounded-md text-sm bg-[rgba(88,166,255,0.1)] border-[rgba(88,166,255,0.4)] text-[#58a6ff]">
+              <div class="flex items-start gap-3">
+                <svg
+                  class="w-5 h-5 mt-0.5 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  role="img"
+                  aria-label="Info"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+                <div class="flex-1">
+                  <p class="m-0 mb-2 font-medium text-[#e6edf3]">{title}</p>
+                  <p class="m-0 text-xs text-[#8b949e]">{description}</p>
+                </div>
+                <button
+                  type="button"
+                  class="px-2 py-1 text-xs font-medium bg-transparent text-[#8b949e] hover:text-[#e6edf3] transition-colors flex-shrink-0"
+                  onClick={() => acpStore.dismissRateLimitPrompt()}
+                  title="Dismiss"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          );
+        })()}
       </Show>
 
       {/* Agent CWD Display */}

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -1,0 +1,264 @@
+// ABOUTME: Detects agent rate-limit and prompt-too-long errors, orchestrates fallback to Chat mode.
+// ABOUTME: Converts agent messages to chat format and creates a new chat conversation.
+
+import type { AgentType } from "@/services/acp";
+import type { AgentMessage } from "@/stores/acp.store";
+import type { Message } from "@/services/chat";
+
+/** Patterns that indicate an agent has hit a rate limit. */
+const RATE_LIMIT_PATTERNS = [
+  "429",
+  "rate limit",
+  "rate_limit",
+  "too many requests",
+  "overloaded",
+  "limit exceeded",
+  "hit your limit",
+  "hit the limit",
+  "exceeded your",
+  "capacity",
+  "try again later",
+];
+
+/**
+ * Check whether an error message indicates a rate limit was hit.
+ */
+export function isRateLimitError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return RATE_LIMIT_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+/** Patterns that indicate the agent's context window is exhausted. */
+const PROMPT_TOO_LONG_PATTERNS = [
+  "prompt is too long",
+  "prompt too long",
+  "context length exceeded",
+  "context_length_exceeded",
+  "maximum context length",
+  "token limit",
+  "max_tokens",
+  "input too long",
+  "request too large",
+  "content too large",
+  "exceeds the model",
+  "ran out of room",
+  "too many tokens",
+  "exceeds the maximum",
+  "number of input tokens",
+  "reduce your prompt",
+  "reduce the number of messages",
+];
+
+/**
+ * Check whether a message indicates the agent's context window is full.
+ *
+ * Also catches the CLI's raw API error form:
+ *   `API Error: 400 {"type":"error","error":{"type":"invalid_request_error",...}}`
+ * which wraps the Anthropic error without always including recognizable keywords.
+ */
+export function isPromptTooLongError(message: string): boolean {
+  const lower = message.toLowerCase();
+  if (PROMPT_TOO_LONG_PATTERNS.some((pattern) => lower.includes(pattern))) {
+    return true;
+  }
+  if (
+    lower.includes("api error: 400") &&
+    lower.includes("invalid_request_error")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check whether a message indicates any agent-level failure that warrants
+ * falling back to Chat mode (rate limit OR context exhaustion).
+ */
+export function isAgentFallbackError(message: string): boolean {
+  return isRateLimitError(message) || isPromptTooLongError(message);
+}
+
+/**
+ * Keywords extracted from agent model IDs mapped to their Seren chat equivalents.
+ * Order matters — first match wins, so more specific patterns come first.
+ */
+const AGENT_TO_SEREN_MODEL: Array<[pattern: string, serenId: string]> = [
+  ["opus-4", "anthropic/claude-opus-4.5"],
+  ["opus", "anthropic/claude-opus-4.5"],
+  ["sonnet-4", "anthropic/claude-sonnet-4"],
+  ["sonnet", "anthropic/claude-sonnet-4"],
+  ["haiku", "anthropic/claude-haiku-4.5"],
+  ["gpt-5", "openai/gpt-5"],
+  ["gpt-4o-mini", "openai/gpt-4o-mini"],
+  ["gpt-4o", "openai/gpt-4o"],
+  ["o1-mini", "openai/gpt-4o-mini"],
+  ["o1", "openai/gpt-4o"],
+  ["gemini-2.5-pro", "google/gemini-2.5-pro"],
+  ["gemini-2.5-flash", "google/gemini-2.5-flash"],
+  ["gemini-3", "google/gemini-3-flash-preview"],
+  ["gemini", "google/gemini-2.5-pro"],
+];
+
+/** Default Seren model per agent type when no match is found. */
+const DEFAULT_SEREN_MODELS: Record<AgentType, string> = {
+  "claude-code": "anthropic/claude-sonnet-4",
+  codex: "openai/gpt-4o",
+};
+
+/**
+ * Map an agent's current model ID to the equivalent Seren chat model ID.
+ * Falls back to a sensible default for the agent type if no match.
+ */
+export function mapAgentModelToChat(
+  agentModelId: string | undefined,
+  agentType: AgentType,
+): string {
+  if (agentModelId) {
+    const lower = agentModelId.toLowerCase();
+    for (const [pattern, serenId] of AGENT_TO_SEREN_MODEL) {
+      if (lower.includes(pattern)) {
+        return serenId;
+      }
+    }
+  }
+  return DEFAULT_SEREN_MODELS[agentType] ?? "anthropic/claude-sonnet-4";
+}
+
+/**
+ * Get a human-readable display name for a Seren model ID.
+ */
+export function getModelDisplayName(serenModelId: string): string {
+  const names: Record<string, string> = {
+    "anthropic/claude-opus-4.5": "Claude Opus 4.5",
+    "anthropic/claude-sonnet-4": "Claude Sonnet 4",
+    "anthropic/claude-haiku-4.5": "Claude Haiku 4.5",
+    "openai/gpt-5": "GPT-5",
+    "openai/gpt-4o": "GPT-4o",
+    "openai/gpt-4o-mini": "GPT-4o Mini",
+    "google/gemini-2.5-pro": "Gemini 2.5 Pro",
+    "google/gemini-2.5-flash": "Gemini 2.5 Flash",
+    "google/gemini-3-flash-preview": "Gemini 3 Flash",
+  };
+  return names[serenModelId] ?? serenModelId;
+}
+
+/**
+ * Convert agent messages into chat Message[] for the chat conversation store.
+ * Only user and assistant messages carry over — tool calls, diffs, and thoughts
+ * are agent-specific artifacts that don't render in chat.
+ */
+export function agentMessagesToChatMessages(
+  messages: AgentMessage[],
+): Message[] {
+  const converted: Message[] = [];
+
+  for (const msg of messages) {
+    if (msg.type === "user") {
+      converted.push({
+        id: msg.id,
+        role: "user",
+        content: msg.content,
+        timestamp: msg.timestamp,
+        status: "complete",
+      });
+    } else if (msg.type === "assistant") {
+      converted.push({
+        id: msg.id,
+        role: "assistant",
+        content: msg.content,
+        timestamp: msg.timestamp,
+        status: "complete",
+        duration: msg.duration,
+      });
+    }
+  }
+
+  return converted;
+}
+
+/**
+ * Build the redirect notice shown at the top of the new chat conversation.
+ */
+export function buildRedirectMessage(
+  agentType: AgentType,
+  modelDisplayName: string,
+  reason: "rate_limit" | "prompt_too_long" = "rate_limit",
+): Message {
+  const agentName = agentType === "codex" ? "Codex" : "Claude Code";
+  const reasonText =
+    reason === "prompt_too_long"
+      ? `${agentName} agent's context window is full.`
+      : `${agentName} agent hit its rate limit.`;
+
+  return {
+    id: crypto.randomUUID(),
+    role: "system",
+    content:
+      `${reasonText} ` +
+      `Your conversation has been moved here so you can continue in Chat with ${modelDisplayName}. ` +
+      "Pick up where you left off — your full history is preserved above.",
+    timestamp: Date.now(),
+    status: "complete",
+  };
+}
+
+/**
+ * Orchestrate the full agent-to-chat switchover.
+ *
+ * 1. Map the agent's current model to its Seren chat equivalent
+ * 2. Convert agent messages to chat Message[]
+ * 3. Create a new chat conversation
+ * 4. Import the message history + redirect notice
+ * 5. Switch the UI from Agent → Chat mode
+ *
+ * Returns the new conversation ID, or null if the switchover failed.
+ */
+export async function performAgentFallback(
+  agentType: AgentType,
+  agentMessages: AgentMessage[],
+  agentModelId?: string,
+  sessionTitle?: string,
+  reason: "rate_limit" | "prompt_too_long" = "rate_limit",
+): Promise<string | null> {
+  // Lazy imports to avoid circular dependency between stores
+  const { chatStore } = await import("@/stores/chat.store");
+  const { acpStore } = await import("@/stores/acp.store");
+  const { providerStore } = await import("@/stores/provider.store");
+
+  const chatModelId = mapAgentModelToChat(agentModelId, agentType);
+  const modelDisplayName = getModelDisplayName(chatModelId);
+  const agentName = agentType === "codex" ? "Codex" : "Claude";
+  const title = sessionTitle || `${agentName} Agent (continued)`;
+
+  try {
+    // Set the model before creating conversation so it picks up the right model
+    providerStore.setActiveProvider("seren");
+    providerStore.setActiveModel(chatModelId);
+    chatStore.setModel(chatModelId);
+
+    // Create the chat conversation
+    const conversation = await chatStore.createConversation(title);
+
+    // Convert and import agent history
+    const chatMessages = agentMessagesToChatMessages(agentMessages);
+    const redirectNotice = buildRedirectMessage(
+      agentType,
+      modelDisplayName,
+      reason,
+    );
+
+    chatStore.setMessages(conversation.id, [...chatMessages, redirectNotice]);
+
+    // Switch UI from Agent → Chat
+    acpStore.setAgentModeEnabled(false);
+
+    console.info(
+      `[AgentFallback] Switched to chat: conversation=${conversation.id}, model=${chatModelId}, reason=${reason} (from agent model ${agentModelId ?? "unknown"})`,
+    );
+
+    return conversation.id;
+  } catch (error) {
+    console.error("[AgentFallback] Failed to perform fallback:", error);
+    return null;
+  }
+}

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -3,6 +3,11 @@
 
 import { createStore, produce } from "solid-js/store";
 import { onRuntimeEvent } from "@/lib/bridge";
+import {
+  isPromptTooLongError,
+  isRateLimitError,
+  performAgentFallback,
+} from "@/lib/rate-limit-fallback";
 
 type UnlistenFn = () => void;
 
@@ -54,6 +59,10 @@ export interface ActiveSession {
   error?: string | null;
   /** Timestamp when the current prompt started */
   promptStartTime?: number;
+  /** Set when the agent hits a rate limit — triggers fallback to Chat mode */
+  rateLimitHit?: boolean;
+  /** Set when the agent's context window is full — triggers fallback to Chat mode */
+  promptTooLong?: boolean;
 }
 
 interface AcpState {
@@ -198,6 +207,30 @@ export const acpStore = {
   get cwd(): string | null {
     const session = this.activeSession;
     return session?.cwd ?? null;
+  },
+
+  /** Whether the active session hit a rate limit. */
+  get rateLimitHit(): boolean {
+    const session = this.activeSession;
+    return session?.rateLimitHit === true;
+  },
+
+  /** Whether the active session's context window is full. */
+  get promptTooLong(): boolean {
+    const session = this.activeSession;
+    return session?.promptTooLong === true;
+  },
+
+  /** Whether the active session needs a fallback to Chat mode. */
+  get agentFallbackNeeded(): boolean {
+    return this.rateLimitHit || this.promptTooLong;
+  },
+
+  /** Reason for the fallback, or null if no fallback is needed. */
+  get agentFallbackReason(): "rate_limit" | "prompt_too_long" | null {
+    if (this.promptTooLong) return "prompt_too_long";
+    if (this.rateLimitHit) return "rate_limit";
+    return null;
   },
 
   // ============================================================================
@@ -584,10 +617,13 @@ export const acpStore = {
         return;
       }
 
-      // Skip addErrorMessage for cancellation — the error event handler
-      // already recorded it in chat history. Adding it again here would
-      // create a duplicate banner.
-      if (!message.includes("Task cancelled")) {
+      // Skip addErrorMessage for cancellation and prompt-too-long — the error
+      // event handler already recorded them and triggers the appropriate
+      // recovery flow. Adding them again here would create duplicates.
+      if (
+        !message.includes("Task cancelled") &&
+        !isPromptTooLongError(message)
+      ) {
         this.addErrorMessage(sessionId, message);
       }
     }
@@ -726,6 +762,40 @@ export const acpStore = {
    */
   setAgentModeEnabled(enabled: boolean) {
     setState("agentModeEnabled", enabled);
+  },
+
+  /**
+   * Accept the fallback: switch agent history to a Chat conversation.
+   */
+  async acceptRateLimitFallback(): Promise<string | null> {
+    const session = this.activeSession;
+    if (!session) return null;
+
+    const agentType = session.info.agentType;
+    const messages = [...session.messages];
+    const agentModelId = undefined; // Agent model not tracked in session info
+    const title = undefined; // Session title not tracked in seren-local
+    const reason = this.agentFallbackReason ?? "rate_limit";
+
+    // Clear the flags first so the banner disappears immediately
+    const sessionId = state.activeSessionId;
+    if (sessionId) {
+      setState("sessions", sessionId, "rateLimitHit", false);
+      setState("sessions", sessionId, "promptTooLong", false);
+    }
+
+    return performAgentFallback(agentType, messages, agentModelId, title, reason);
+  },
+
+  /**
+   * Dismiss the rate limit / prompt-too-long banner without switching.
+   */
+  dismissRateLimitPrompt() {
+    const sessionId = state.activeSessionId;
+    if (sessionId) {
+      setState("sessions", sessionId, "rateLimitHit", false);
+      setState("sessions", sessionId, "promptTooLong", false);
+    }
   },
 
   /**
@@ -912,6 +982,28 @@ export const acpStore = {
               timeoutMsg,
             ]);
           }
+        } else if (isPromptTooLongError(String(event.data.error))) {
+          // Context window full — automatically switch to chat mode
+          console.info(
+            "[AcpStore] Prompt too long detected, automatically switching to chat mode",
+          );
+          setState("sessions", sessionId, "promptTooLong", true);
+          this.addErrorMessage(sessionId, event.data.error);
+
+          this.acceptRateLimitFallback().catch((err) => {
+            console.error("[AcpStore] Auto-failover failed:", err);
+          });
+        } else if (isRateLimitError(String(event.data.error))) {
+          // Rate limit hit — automatically switch to chat mode
+          console.info(
+            "[AcpStore] Rate limit detected, automatically switching to chat mode",
+          );
+          setState("sessions", sessionId, "rateLimitHit", true);
+          this.addErrorMessage(sessionId, event.data.error);
+
+          this.acceptRateLimitFallback().catch((err) => {
+            console.error("[AcpStore] Auto-failover failed:", err);
+          });
         } else {
           this.addErrorMessage(sessionId, event.data.error);
         }
@@ -1110,6 +1202,21 @@ export const acpStore = {
         timestamp: Date.now(),
         duration,
       };
+      // If the agent's response is a prompt-too-long error (context window full),
+      // automatically switch to Chat mode with history preserved.
+      if (isPromptTooLongError(session.streamingContent)) {
+        console.info(
+          "[AcpStore] Prompt too long detected in streamed content, switching to Chat mode",
+        );
+        setState("sessions", sessionId, "promptTooLong", true);
+        this.acceptRateLimitFallback().catch((err) => {
+          console.error(
+            "[AcpStore] Auto-failover from streamed content failed:",
+            err,
+          );
+        });
+      }
+
       setState("sessions", sessionId, "messages", (msgs) => [...msgs, message]);
       setState("sessions", sessionId, "streamingContent", "");
       // Clear the start time


### PR DESCRIPTION
## Summary
- New `src/lib/rate-limit-fallback.ts` module with full error detection and agent-to-chat switchover orchestration
- Detects rate limits (429, overloaded, etc.) and context window exhaustion (prompt too long, context length exceeded, etc.) in both error events and streamed content
- Automatically switches to Chat mode with conversation history preserved — creates a new chat conversation, converts agent messages, sets the appropriate model, and disables agent mode
- Informational banner appears briefly showing the reason and auto-dismiss
- Skip duplicate error messages for prompt-too-long errors in the sendPrompt catch path

## Files changed
- `src/lib/rate-limit-fallback.ts` — **new** (264 lines): error detection patterns, model mapping, message conversion, fallback orchestration
- `src/stores/acp.store.ts` — session flags (`rateLimitHit`, `promptTooLong`), getters, `acceptRateLimitFallback()`, `dismissRateLimitPrompt()`, detection in error handler + streaming finalizer
- `src/components/chat/AgentChat.tsx` — fallback banner UI with dismiss button

## Desktop commits ported
- `bb856ea3` — auto-failover to Chat when agent streams 'prompt is too long'
- Plus underlying rate limit fallback infrastructure

Closes #11

## Test plan
- [ ] Verify prompt-too-long errors in error events trigger automatic switch to Chat
- [ ] Verify prompt-too-long errors in streamed content trigger automatic switch to Chat
- [ ] Verify rate limit errors (429) trigger automatic switch to Chat
- [ ] Verify conversation history is preserved in the new chat conversation
- [ ] Verify the fallback banner appears and can be dismissed
- [ ] Verify the correct chat model is selected after failover
- [ ] Verify normal errors still show the standard error banner (no false positives)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com