### PR TITLE
feat: expand file listing detection and add catch-all verbose output collapse

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -25,6 +25,7 @@ import {
   getModelDisplayName,
   mapAgentModelToChat,
 } from "@/lib/rate-limit-fallback";
+import { collapseVerboseOutput } from "@/lib/verbose-output";
 import { formatDurationWithVerb } from "@/lib/format-duration";
 import { pickAndReadImages, toDataUrl } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
@@ -404,9 +405,11 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           <article class="px-5 py-4 border-b border-[#21262d]">
             <div
               class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_code]:bg-[#21262d] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline"
-              innerHTML={collapseBuildOutput(
-                collapseDirectoryListings(
-                  renderMarkdown(message.content),
+              innerHTML={collapseVerboseOutput(
+                collapseBuildOutput(
+                  collapseDirectoryListings(
+                    renderMarkdown(message.content),
+                  ),
                 ),
               )}
             />

--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -19,6 +19,7 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
+import { collapseVerboseOutput } from "@/lib/verbose-output";
 import { pickAndReadImages } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
@@ -760,9 +761,11 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
                           class="chat-message-content text-[14px] leading-[1.7] text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_h1]:text-[1.3em] [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-3 [&_h1]:text-[#f0f6fc] [&_h1]:border-b [&_h1]:border-[#21262d] [&_h1]:pb-2 [&_h2]:text-[1.15em] [&_h2]:font-semibold [&_h2]:mt-4 [&_h2]:mb-2 [&_h2]:text-[#f0f6fc] [&_h3]:text-[1.05em] [&_h3]:font-semibold [&_h3]:mt-3 [&_h3]:mb-2 [&_h3]:text-[#f0f6fc] [&_code]:bg-[#1c2333] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_li]:leading-[1.6] [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline [&_strong]:text-[#f0f6fc] [&_strong]:font-semibold"
                           innerHTML={
                             message.role === "assistant"
-                              ? collapseBuildOutput(
-                                  collapseDirectoryListings(
-                                    renderMarkdown(message.content),
+                              ? collapseVerboseOutput(
+                                  collapseBuildOutput(
+                                    collapseDirectoryListings(
+                                      renderMarkdown(message.content),
+                                    ),
                                   ),
                                 )
                               : escapeHtmlWithLinks(message.content)

--- a/src/lib/directory-listing.ts
+++ b/src/lib/directory-listing.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Detects Unix directory listing output and provides collapse utilities.
-// ABOUTME: Used to suppress verbose ls output in chat and agent chat panels.
+// ABOUTME: Detects verbose file-listing output and provides collapse utilities.
+// ABOUTME: Catches ls -l, find, path listings, and traversal errors in chat panels.
 
 /** Unix ls -l permission format: drwxr-xr-x, -rw-r--r--, etc. */
 const LS_LINE = /^[dlcbps-][rwxsStT-]{9}\s/;
@@ -7,12 +7,45 @@ const LS_LINE = /^[dlcbps-][rwxsStT-]{9}\s/;
 /** Total line header from ls -l output */
 const TOTAL_LINE = /^total \d+$/;
 
+/** Absolute Unix path: starts with / followed by at least one path segment */
+const UNIX_PATH = /^\/[\w.@~+-]/;
+
+/** Absolute Windows path: C:\ or similar */
+const WIN_PATH = /^[A-Za-z]:[/\\]/;
+
+/** Relative path with at least two segments: src/lib/file.ts, artifacts/bot/script.py */
+const RELATIVE_PATH = /^[\w.@~+-][\w.@~+-]*\/[\w.@~+-]/;
+
+/** Path followed by an error: /path/to/dir: Operation not permitted (os error 1) */
+const PATH_ERROR =
+  /^\/[\w.@~+-].*:\s+(Operation not permitted|Permission denied|No such file|Is a directory|Not a directory)/;
+
+/** find-style error: find: '/path': Permission denied */
+const FIND_ERROR = /^(find|ls|stat):\s/;
+
+/** tree-style lines: ├── file.txt, └── dir/, │ */
+const TREE_LINE = /^[│├└─\s]{2,}/;
+
 /** Minimum consecutive matching lines to trigger detection */
 const MIN_CONSECUTIVE = 5;
 
+/** Returns true if a line looks like file-listing output. */
+function isListingLine(trimmed: string): boolean {
+  return (
+    LS_LINE.test(trimmed) ||
+    TOTAL_LINE.test(trimmed) ||
+    PATH_ERROR.test(trimmed) ||
+    FIND_ERROR.test(trimmed) ||
+    TREE_LINE.test(trimmed) ||
+    UNIX_PATH.test(trimmed) ||
+    WIN_PATH.test(trimmed) ||
+    RELATIVE_PATH.test(trimmed)
+  );
+}
+
 /**
- * Returns true if the text is predominantly a Unix directory listing.
- * Detects `ls -l` style output with permission bits.
+ * Returns true if the text is predominantly a file listing.
+ * Detects `ls -l`, `find`, bare path listings, and traversal errors.
  */
 export function isDirectoryListing(text: string): boolean {
   const lines = text.split("\n");
@@ -20,7 +53,7 @@ export function isDirectoryListing(text: string): boolean {
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed) continue;
-    if (LS_LINE.test(trimmed) || TOTAL_LINE.test(trimmed)) {
+    if (isListingLine(trimmed)) {
       consecutive++;
       if (consecutive >= MIN_CONSECUTIVE) return true;
     } else {
@@ -31,16 +64,29 @@ export function isDirectoryListing(text: string): boolean {
 }
 
 /**
- * Returns a one-line summary of a directory listing.
- * Counts lines matching ls -l format.
+ * Returns a one-line summary of a file listing.
+ * Counts lines matching any listing pattern.
  */
 export function summarizeDirectoryListing(text: string): string {
   const lines = text.split("\n");
   let count = 0;
+  let hasErrors = false;
   for (const line of lines) {
-    if (LS_LINE.test(line.trim())) count++;
+    const trimmed = line.trim();
+    if (isListingLine(trimmed)) {
+      count++;
+      if (
+        !hasErrors &&
+        (PATH_ERROR.test(trimmed) || FIND_ERROR.test(trimmed))
+      ) {
+        hasErrors = true;
+      }
+    }
   }
-  return `Directory listing (${count} ${count === 1 ? "entry" : "entries"})`;
+  if (hasErrors) {
+    return `File listing with errors (${count} ${count === 1 ? "line" : "lines"})`;
+  }
+  return `File listing (${count} ${count === 1 ? "entry" : "entries"})`;
 }
 
 /** Decode basic HTML entities for detection in rendered HTML. */
@@ -54,7 +100,7 @@ function decodeBasicHtmlEntities(html: string): string {
 }
 
 /**
- * Post-processes rendered HTML to collapse directory listing blocks.
+ * Post-processes rendered HTML to collapse file listing blocks.
  * Wraps detected blocks in native <details><summary> elements.
  */
 export function collapseDirectoryListings(html: string): string {

--- a/src/lib/verbose-output.ts
+++ b/src/lib/verbose-output.ts
@@ -1,0 +1,82 @@
+// ABOUTME: Catch-all collapser for large output blocks not caught by specific detectors.
+// ABOUTME: Collapses any block exceeding line/character thresholds into a details element.
+
+/** Minimum number of lines to trigger collapse */
+const MIN_LINES = 20;
+
+/** Minimum character count to trigger collapse */
+const MIN_CHARS = 2000;
+
+/** Decode basic HTML entities for measurement. */
+function decodeBasicHtmlEntities(html: string): string {
+  return html
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/**
+ * Generates a summary label for a large output block.
+ */
+function summarizeLargeOutput(text: string): string {
+  const lineCount = text.split("\n").filter((l) => l.trim()).length;
+  return `Large output (${lineCount} lines)`;
+}
+
+/**
+ * Post-processes rendered HTML to collapse large output blocks that weren't
+ * already collapsed by the directory-listing or build-output detectors.
+ *
+ * This is a catch-all — it should be called LAST in the collapse chain.
+ */
+export function collapseVerboseOutput(html: string): string {
+  // Skip if already collapsed by a specific detector
+  if (
+    html.includes("dir-listing-collapse") ||
+    html.includes("build-output-collapse")
+  ) {
+    return html;
+  }
+
+  // Handle large content inside <pre><code> blocks
+  const modified = html.replace(
+    /(<pre[^>]*><code[^>]*>)([\s\S]*?)(<\/code><\/pre>)/g,
+    (match, _open: string, content: string, _close: string) => {
+      const decoded = decodeBasicHtmlEntities(content);
+      const lines = decoded.split("\n").filter((l) => l.trim());
+      if (lines.length >= MIN_LINES || decoded.length >= MIN_CHARS) {
+        const summary = summarizeLargeOutput(decoded);
+        return `<details class="verbose-output-collapse"><summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>${match}</details>`;
+      }
+      return match;
+    },
+  );
+
+  if (modified !== html) return modified;
+
+  // Handle <br>-separated content
+  if (!/<pre[\s>]/.test(html)) {
+    const segments = html.split(/<br\s*\/?>/i);
+    const plainText = segments
+      .map((s) => decodeBasicHtmlEntities(s))
+      .join("\n");
+    const nonEmptyLines = plainText.split("\n").filter((l) => l.trim());
+
+    if (
+      nonEmptyLines.length >= MIN_LINES ||
+      plainText.length >= MIN_CHARS
+    ) {
+      const summary = summarizeLargeOutput(plainText);
+      return [
+        '<details class="verbose-output-collapse">',
+        `<summary style="cursor:pointer;padding:0.25em 0;font-size:0.85em">${summary}</summary>`,
+        `<pre style="white-space:pre-wrap;margin:0.5em 0;font-size:12px;color:inherit">${html}</pre>`,
+        "</details>",
+      ].join("");
+    }
+  }
+
+  return html;
+}


### PR DESCRIPTION
## Summary
- **Expanded directory listing detection**: now catches find output, bare Unix/Windows paths, relative paths, tree command output, and permission/traversal errors
- **New verbose-output.ts**: catch-all collapser for large output blocks (20+ lines or 2000+ chars) not caught by specific detectors
- Both AgentChat and ChatContent rendering pipelines updated with collapseVerboseOutput as outermost wrapper

## Desktop commits ported
- b7787b5a — expand directory listing detection to catch find output and bare paths
- 90239e06 — collapse verbose output including relative paths and large data dumps

## Remaining unportable commits
All remaining desktop commits require Rust backend, thread store, skills, Windows-specific, or code signing infrastructure. The desktop-to-local port is now complete.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com