### PR TITLE
feat: spawn cascade guard, sendPrompt race fix, file link opening

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -21,6 +21,7 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
+import { openFileInTab } from "@/lib/files/service";
 import {
   getModelDisplayName,
   mapAgentModelToChat,
@@ -482,7 +483,40 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           if (link) {
             e.preventDefault();
             const url = link.dataset.externalUrl;
-            if (url) openExternalLink(url);
+            if (url) {
+              // Detect local file paths and open them in the editor
+              const isFilePath =
+                url.startsWith("/") ||
+                url.startsWith("./") ||
+                url.startsWith("../") ||
+                url.startsWith("~");
+              if (isFilePath && !url.startsWith("//")) {
+                const cwd = acpStore.cwd;
+                const resolved =
+                  url.startsWith("/") || url.startsWith("~")
+                    ? url
+                    : cwd
+                      ? `${cwd.replace(/\/$/, "")}/${url}`
+                      : url;
+                openFileInTab(resolved)
+                  .then(() => {
+                    window.dispatchEvent(
+                      new CustomEvent("seren:open-panel", {
+                        detail: "editor",
+                      }),
+                    );
+                  })
+                  .catch((err) =>
+                    console.warn(
+                      "[AgentChat] Failed to open file:",
+                      resolved,
+                      err,
+                    ),
+                  );
+              } else {
+                openExternalLink(url);
+              }
+            }
             return;
           }
           const copyBtn = target.closest(".code-copy-btn") as HTMLElement;

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -109,6 +109,32 @@ let globalUnsubscribe: UnlistenFn | null = null;
 /** Guard against concurrent auto-recovery spawns in sendPrompt. */
 let recoveryInFlight: Promise<string | null> | null = null;
 
+/** Spawn cascade guard: track recent failures per session to prevent infinite loops. */
+const SPAWN_CASCADE_WINDOW_MS = 30_000;
+const SPAWN_CASCADE_MAX_FAILURES = 3;
+const spawnFailureTimestamps = new Map<string, number[]>();
+
+function recordSpawnFailure(sessionId: string): void {
+  const now = Date.now();
+  const timestamps = spawnFailureTimestamps.get(sessionId) ?? [];
+  timestamps.push(now);
+  const cutoff = now - SPAWN_CASCADE_WINDOW_MS;
+  const recent = timestamps.filter((t) => t >= cutoff);
+  spawnFailureTimestamps.set(sessionId, recent);
+}
+
+function isSpawnCascading(sessionId: string): boolean {
+  const now = Date.now();
+  const timestamps = spawnFailureTimestamps.get(sessionId) ?? [];
+  const cutoff = now - SPAWN_CASCADE_WINDOW_MS;
+  const recent = timestamps.filter((t) => t >= cutoff);
+  return recent.length >= SPAWN_CASCADE_MAX_FAILURES;
+}
+
+function clearSpawnFailures(sessionId: string): void {
+  spawnFailureTimestamps.delete(sessionId);
+}
+
 // ============================================================================
 // Store
 // ============================================================================
@@ -261,6 +287,20 @@ export const acpStore = {
     agentType?: AgentType,
   ): Promise<string | null> {
     const resolvedAgentType = agentType ?? state.selectedAgentType;
+
+    // Prevent infinite spawn-crash-respawn cascades
+    if (isSpawnCascading(resolvedAgentType)) {
+      console.error(
+        `[AcpStore] Spawn cascade detected for ${resolvedAgentType} — ${SPAWN_CASCADE_MAX_FAILURES} failures in ${SPAWN_CASCADE_WINDOW_MS / 1000}s. Stopping auto-resume.`,
+      );
+      setState(
+        "error",
+        "Agent failed to start after multiple attempts. Please try again or check Settings.",
+      );
+      setState("isLoading", false);
+      return null;
+    }
+
     setState("isLoading", true);
     setState("error", null);
 
@@ -402,10 +442,12 @@ export const acpStore = {
       setState("isLoading", false);
       tempUnsubscribe();
 
+      clearSpawnFailures(resolvedAgentType);
       return info.id;
     } catch (error) {
       console.error("[AcpStore] Spawn error:", error);
       tempUnsubscribe();
+      recordSpawnFailure(resolvedAgentType);
       const message =
         error instanceof Error ? error.message : String(error);
       setState("error", message);
@@ -483,6 +525,29 @@ export const acpStore = {
       return;
     }
 
+    // If auto-recovery is in-flight (triggered by another sendPrompt call),
+    // wait for it to complete. Recovery already retries the original prompt,
+    // so proceeding would race and cause "Another prompt is already active".
+    if (recoveryInFlight) {
+      console.info(
+        "[AcpStore] sendPrompt: recovery in-flight, waiting before proceeding...",
+      );
+      await recoveryInFlight;
+      const refreshed = state.sessions[sessionId];
+      if (!refreshed) {
+        console.info(
+          "[AcpStore] sendPrompt: session gone after recovery, aborting",
+        );
+        return;
+      }
+      if (refreshed.info.status === "prompting") {
+        console.info(
+          "[AcpStore] sendPrompt: session already prompting after recovery, aborting duplicate",
+        );
+        return;
+      }
+    }
+
     // Wait for session to be ready before sending prompt
     const readyEntry = sessionReadyPromises.get(sessionId);
     if (readyEntry) {
@@ -491,6 +556,21 @@ export const acpStore = {
       );
       await readyEntry.promise;
       console.info("[AcpStore] sendPrompt: session is now ready");
+    }
+
+    // Re-check after async waits — recovery may have started while we waited.
+    if (recoveryInFlight) {
+      console.info(
+        "[AcpStore] sendPrompt: recovery started during ready-wait, deferring...",
+      );
+      await recoveryInFlight;
+      const refreshed = state.sessions[sessionId];
+      if (!refreshed || refreshed.info.status === "prompting") {
+        console.info(
+          "[AcpStore] sendPrompt: session busy after recovery, aborting duplicate",
+        );
+        return;
+      }
     }
 
     // Optimistically mark as prompting so the UI can show a loading state
@@ -920,6 +1000,12 @@ export const acpStore = {
         break;
 
       case "error":
+        // Log full error content for diagnostics (helps debug cascade crashes)
+        console.error(
+          `[AcpStore] Error event for session ${sessionId}:`,
+          event.data.error,
+        );
+
         // Clean up any in-flight streaming and tool cards
         this.finalizeStreamingContent(sessionId);
         this.markPendingToolCallsComplete(sessionId);


### PR DESCRIPTION
## Summary

### Stability
- **Spawn cascade guard**: tracks failures per agent type (3 failures in 30s = stop). Prevents infinite spawn-crash-respawn loops with an actionable error message.
- **sendPrompt race fix**: checks `recoveryInFlight` both before AND after the ready-promise wait. Prevents duplicate prompts when recovery starts concurrently.
- **Error event logging**: full error content logged for crash loop diagnostics.

### UX
- **File link opening**: clicking file paths in agent output (absolute `/path`, relative `./path`, or `~/path`) now opens the file in the editor panel. External URLs continue to open in browser.

## Desktop commits ported
- `884c8a30` (TS portion) — spawn cascade guard
- `99e6951c` (TS portion) — sendPrompt race fix (skills context part skipped)
- `82539890` — open file links from agent chat

Closes #14

## Test plan
- [ ] Rapidly fail agent spawn 3+ times in 30s and verify cascade stops with error message
- [ ] Verify normal spawn after 30s window resets
- [ ] Trigger auto-recovery while sendPrompt is waiting — verify no duplicate prompts
- [ ] Click a file path in agent output — verify file opens in editor panel
- [ ] Click an external URL in agent output — verify it opens in browser
- [ ] Verify `//protocol` URLs are not treated as file paths

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com