### PR TITLE
feat: session title persistence, stale detection, fork conversation

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -59,6 +59,19 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const [attachedImages, setAttachedImages] = createSignal<ImageAttachment[]>(
     [],
   );
+  const [forking, setForking] = createSignal(false);
+
+  const handleForkFromMessage = async (messageId: string) => {
+    if (forking()) return;
+    setForking(true);
+    try {
+      await acpStore.forkConversation(messageId);
+    } catch (e) {
+      console.error("[AgentChat] Fork failed:", e);
+    } finally {
+      setForking(false);
+    }
+  };
   const [commandStatus, setCommandStatus] = createSignal<string | null>(null);
   const [commandPopupIndex, setCommandPopupIndex] = createSignal(0);
   const [historyIndex, setHistoryIndex] = createSignal(-1);
@@ -390,11 +403,22 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
     switch (message.type) {
       case "user":
         return (
-          <article class="px-5 py-4 bg-[#161b22] border-b border-[#21262d]">
+          <article class="group/msg relative px-5 py-4 bg-[#161b22] border-b border-[#21262d]">
             <div
               class="text-sm leading-relaxed text-[#e6edf3] whitespace-pre-wrap"
               innerHTML={escapeHtmlWithLinks(message.content)}
             />
+            <button
+              type="button"
+              class="absolute top-2 right-2 p-1 rounded text-[#484f58] hover:text-[#e6edf3] hover:bg-[#30363d] opacity-0 group-hover/msg:opacity-100 transition-opacity"
+              title="Fork conversation from here"
+              disabled={forking()}
+              onClick={() => handleForkFromMessage(message.id)}
+            >
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" role="img" aria-label="Fork">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 3v6m0 0a3 3 0 103 3V9m-3 3a3 3 0 10-3 3m12-9v6m0 0a3 3 0 103 3v-3m-3 3a3 3 0 10-3 3" />
+              </svg>
+            </button>
           </article>
         );
 
@@ -403,7 +427,7 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
           ? formatDurationWithVerb(message.duration)
           : null;
         return (
-          <article class="px-5 py-4 border-b border-[#21262d]">
+          <article class="group/msg relative px-5 py-4 border-b border-[#21262d]">
             <div
               class="text-sm leading-relaxed text-[#e6edf3] break-words [&_p]:m-0 [&_p]:mb-3 [&_p:last-child]:mb-0 [&_code]:bg-[#21262d] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:font-mono [&_code]:text-[13px] [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-3 [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_code]:text-[13px] [&_pre_code]:leading-normal [&_ul]:my-2 [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:pl-6 [&_li]:my-1 [&_blockquote]:border-l-[3px] [&_blockquote]:border-[#30363d] [&_blockquote]:my-3 [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_a]:text-[#58a6ff] [&_a]:no-underline [&_a:hover]:underline"
               innerHTML={collapseVerboseOutput(
@@ -419,6 +443,17 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
                 &#10043; {durationDisplay!.verb} for {durationDisplay!.duration}
               </div>
             </Show>
+            <button
+              type="button"
+              class="absolute top-2 right-2 p-1 rounded text-[#484f58] hover:text-[#e6edf3] hover:bg-[#30363d] opacity-0 group-hover/msg:opacity-100 transition-opacity"
+              title="Fork conversation from here"
+              disabled={forking()}
+              onClick={() => handleForkFromMessage(message.id)}
+            >
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" role="img" aria-label="Fork">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 3v6m0 0a3 3 0 103 3V9m-3 3a3 3 0 10-3 3m12-9v6m0 0a3 3 0 103 3v-3m-3 3a3 3 0 10-3 3" />
+              </svg>
+            </button>
           </article>
         );
       }

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -55,6 +55,8 @@ export interface ActiveSession {
   streamingContent: string;
   streamingThinking: string;
   cwd: string;
+  /** Derived session title (from first user prompt) */
+  title?: string;
   /** Session-specific error message */
   error?: string | null;
   /** Timestamp when the current prompt started */
@@ -235,6 +237,12 @@ export const acpStore = {
     return session?.cwd ?? null;
   },
 
+  /** Derived title for the active session. */
+  get sessionTitle(): string | null {
+    const session = this.activeSession;
+    return session?.title ?? null;
+  },
+
   /** Whether the active session hit a rate limit. */
   get rateLimitHit(): boolean {
     const session = this.activeSession;
@@ -273,6 +281,37 @@ export const acpStore = {
     } catch (error) {
       console.error("Failed to load available agents:", error);
     }
+
+    this.setupStaleSessionDetection();
+  },
+
+  /**
+   * Set up stale session detection on tab visibility change.
+   * When the user returns to the tab, verify the active session still
+   * exists in the backend. If it died while the tab was hidden, clean up.
+   */
+  setupStaleSessionDetection() {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "visible") return;
+      const sessionId = state.activeSessionId;
+      if (!sessionId) return;
+
+      acpService.listSessions().then((backendSessions) => {
+        const alive = backendSessions.some((s) => s.id === sessionId);
+        if (!alive) {
+          console.warn(
+            `[AcpStore] Session ${sessionId} no longer exists in backend — cleaning up`,
+          );
+          this.terminateSession(sessionId);
+          setState(
+            "error",
+            "Agent session ended unexpectedly. Please start a new session.",
+          );
+        }
+      }).catch((err) => {
+        console.warn("[AcpStore] Failed to check session liveness:", err);
+      });
+    });
   },
 
   // ============================================================================
@@ -599,6 +638,25 @@ export const acpStore = {
     setState("sessions", sessionId, "streamingThinking", "");
     // Track when the prompt started for duration calculation
     setState("sessions", sessionId, "promptStartTime", Date.now());
+
+    // Derive session title from first user prompt
+    if (!state.sessions[sessionId]?.title) {
+      const t = prompt.trim();
+      const title =
+        t.length <= 40
+          ? t.split("\n")[0]
+          : (() => {
+              const sp = t.indexOf(" ", 10);
+              return `${sp > 10 ? t.slice(0, sp) : t.slice(0, 40)}\u2026`;
+            })();
+      setState("sessions", sessionId, "title", title);
+      // Persist to localStorage
+      try {
+        localStorage.setItem(`seren_session_title_${sessionId}`, title);
+      } catch (_) {
+        // localStorage may be unavailable
+      }
+    }
 
     console.log("[AcpStore] Calling acpService.sendPrompt...");
     try {
@@ -1356,6 +1414,65 @@ export const acpStore = {
 
     // Clear pending map
     session.pendingToolCalls.clear();
+  },
+
+  // ============================================================================
+  // Fork
+  // ============================================================================
+
+  /**
+   * Fork the current agent conversation from a specific message.
+   *
+   * Creates a new agent session and copies messages up to `fromMessageId`
+   * into it, giving the user a fresh session with visual context.
+   */
+  async forkConversation(fromMessageId: string): Promise<string | null> {
+    const session = this.activeSession;
+    const sessionId = state.activeSessionId;
+    if (!session || !sessionId) {
+      console.error("[AcpStore] forkConversation: no active session");
+      return null;
+    }
+
+    // Collect messages up to the fork point
+    const forkIndex = session.messages.findIndex(
+      (m) => m.id === fromMessageId,
+    );
+    if (forkIndex === -1) {
+      console.error("[AcpStore] forkConversation: message not found");
+      return null;
+    }
+    const forkedMessages = session.messages.slice(0, forkIndex + 1);
+
+    // Spawn a new session
+    const cwd = session.cwd;
+    const agentType = session.info.agentType;
+    const newSessionId = await this.spawnSession(cwd, agentType);
+    if (!newSessionId) {
+      console.error("[AcpStore] forkConversation: spawn failed");
+      return null;
+    }
+
+    // Copy messages into the new session
+    setState("sessions", newSessionId, "messages", forkedMessages);
+
+    // Set title
+    const forkTitle = `Fork of ${session.title ?? "Agent"}`;
+    setState("sessions", newSessionId, "title", forkTitle);
+    try {
+      localStorage.setItem(
+        `seren_session_title_${newSessionId}`,
+        forkTitle,
+      );
+    } catch (_) {
+      // localStorage may be unavailable
+    }
+
+    console.info(
+      `[AcpStore] Forked session ${sessionId} -> ${newSessionId} at message ${fromMessageId}`,
+    );
+
+    return newSessionId;
   },
 
   // ============================================================================


### PR DESCRIPTION
## Summary
- **Session title persistence**: Derives title from first user prompt (truncated to ~40 chars), persists to localStorage, exposed via `sessionTitle` getter
- **Stale session detection**: On tab focus (`visibilitychange`), checks backend via `listSessions()` — if session no longer exists, terminates and shows error
- **Fork conversation**: `forkConversation(fromMessageId)` spawns a new session, copies messages up to the fork point, sets "Fork of ..." title. Hover-visible fork button on user and assistant messages

Closes #16

## Test plan
- [ ] Send a message and verify session title appears (derived from first prompt)
- [ ] Refresh page — title should persist via localStorage
- [ ] Kill backend session externally, switch tabs, return — should see stale session error
- [ ] Hover over a user or assistant message — fork button should appear
- [ ] Click fork button — new session should spawn with copied messages

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com