### PR TITLE
feat: plan status variants, fallback navigation, drag-and-drop

### DIFF
--- a/src/components/chat/AgentChat.tsx
+++ b/src/components/chat/AgentChat.tsx
@@ -20,6 +20,7 @@ import { collapseBuildOutput } from "@/lib/build-output";
 import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
+import { createDragDrop } from "@/lib/drag-drop";
 import { openExternalLink } from "@/lib/external-link";
 import { openFileInTab } from "@/lib/files/service";
 import {
@@ -58,6 +59,9 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   const [messageQueue, setMessageQueue] = createSignal<string[]>([]);
   const [attachedImages, setAttachedImages] = createSignal<ImageAttachment[]>(
     [],
+  );
+  const { isDragging, setDropTarget } = createDragDrop((files) =>
+    setAttachedImages((prev) => [...prev, ...files]),
   );
   const [forking, setForking] = createSignal(false);
 
@@ -498,7 +502,14 @@ export const AgentChat: Component<AgentChatProps> = (props) => {
   };
 
   return (
-    <div class="flex-1 flex flex-col min-h-0">
+    <div class="relative flex-1 flex flex-col min-h-0" ref={setDropTarget}>
+      <Show when={isDragging()}>
+        <div class="absolute inset-0 bg-[#1f6feb]/10 border-2 border-dashed border-[#1f6feb]/50 rounded-sm z-50 pointer-events-none flex items-center justify-center">
+          <span class="text-[#58a6ff] text-sm font-medium bg-[#0d1117]/90 px-3 py-1.5 rounded-md shadow-sm">
+            Drop files to attach
+          </span>
+        </div>
+      </Show>
       {/* Agent Tab Bar */}
       <Show when={hasSession()}>
         <AgentTabBar onNewSession={startSession} />

--- a/src/lib/drag-drop.ts
+++ b/src/lib/drag-drop.ts
@@ -1,0 +1,118 @@
+// ABOUTME: SolidJS hook for browser file drag-and-drop attachment.
+// ABOUTME: Returns isDragging signal and ref callback for drop target element.
+
+import { createSignal, onCleanup } from "solid-js";
+import type { ImageAttachment } from "@/lib/providers/types";
+
+const SUPPORTED_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpeg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+};
+
+const MAX_BASE64_SIZE = 27 * 1024 * 1024; // ~20MB file = ~27MB base64
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Strip the data URL prefix to get raw base64
+      const base64 = result.split(",")[1];
+      if (!base64) return reject(new Error("Failed to read file as base64"));
+      resolve(base64);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Register browser drag-and-drop handlers on a target element.
+ * Call inside a SolidJS component — cleans up listeners automatically.
+ *
+ * @param onFiles Called with successfully read attachments when files are dropped.
+ * @returns isDragging signal and ref callback to attach to the drop target.
+ */
+export function createDragDrop(onFiles: (attachments: ImageAttachment[]) => void): {
+  isDragging: () => boolean;
+  setDropTarget: (el: HTMLElement) => void;
+} {
+  const [isDragging, setIsDragging] = createSignal(false);
+  let dragCounter = 0;
+  let targetEl: HTMLElement | null = null;
+
+  const handleDragEnter = (e: DragEvent) => {
+    e.preventDefault();
+    dragCounter++;
+    if (dragCounter === 1) setIsDragging(true);
+  };
+
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    dragCounter--;
+    if (dragCounter <= 0) {
+      dragCounter = 0;
+      setIsDragging(false);
+    }
+  };
+
+  const handleDrop = async (e: DragEvent) => {
+    e.preventDefault();
+    dragCounter = 0;
+    setIsDragging(false);
+
+    const files = e.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+
+    const attachments: ImageAttachment[] = [];
+    for (const file of Array.from(files)) {
+      const mimeExt = SUPPORTED_MIME[file.type];
+      if (!mimeExt) continue;
+
+      try {
+        const base64 = await fileToBase64(file);
+        if (base64.length > MAX_BASE64_SIZE) {
+          console.warn("[DragDrop] File too large, skipping:", file.name);
+          continue;
+        }
+        attachments.push({
+          name: file.name,
+          mimeType: file.type,
+          base64,
+        });
+      } catch (error) {
+        console.warn("[DragDrop] Failed to read file:", file.name, error);
+      }
+    }
+
+    if (attachments.length > 0) {
+      onFiles(attachments);
+    }
+  };
+
+  const setDropTarget = (el: HTMLElement) => {
+    targetEl = el;
+    el.addEventListener("dragenter", handleDragEnter);
+    el.addEventListener("dragover", handleDragOver);
+    el.addEventListener("dragleave", handleDragLeave);
+    el.addEventListener("drop", handleDrop);
+  };
+
+  onCleanup(() => {
+    if (targetEl) {
+      targetEl.removeEventListener("dragenter", handleDragEnter);
+      targetEl.removeEventListener("dragover", handleDragOver);
+      targetEl.removeEventListener("dragleave", handleDragLeave);
+      targetEl.removeEventListener("drop", handleDrop);
+    }
+  });
+
+  return { isDragging, setDropTarget };
+}

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -249,7 +249,10 @@ export async function performAgentFallback(
 
     chatStore.setMessages(conversation.id, [...chatMessages, redirectNotice]);
 
-    // Switch UI from Agent → Chat
+    // Switch UI from Agent → Chat: navigate to the new chat conversation so
+    // AgentChat unmounts and subsequent messages go to the chat orchestrator,
+    // not the already-full ACP session.
+    chatStore.setActiveConversation(conversation.id);
     acpStore.setAgentModeEnabled(false);
 
     console.info(

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -1031,13 +1031,15 @@ export const acpStore = {
         // but a final planUpdate may not arrive after the last tool finishes.
         {
           const plan = state.sessions[sessionId]?.plan;
-          if (plan?.some((e) => e.status === "in_progress")) {
+          const isInProgress = (s: string) =>
+            s === "in_progress" || s === "inprogress" || s === "inProgress";
+          if (plan?.some((e) => isInProgress(e.status))) {
             setState(
               "sessions",
               sessionId,
               "plan",
               plan.map((e) =>
-                e.status === "in_progress" ? { ...e, status: "completed" } : e,
+                isInProgress(e.status) ? { ...e, status: "completed" } : e,
               ),
             );
           }


### PR DESCRIPTION
## Summary
- **Plan entry status variant fix**: promptComplete now matches in_progress, inprogress, and inProgress when cleaning up plan entries - fixes stuck yellow spinner
- **Fallback chat navigation**: After prompt-too-long agent-to-chat fallback, chatStore.setActiveConversation() is called so the UI navigates to the new chat conversation and AgentChat unmounts - prevents infinite loop
- **Drag and drop file attachment**: New createDragDrop hook using browser HTML5 Drag and Drop API (adapted from desktop Tauri onDragDropEvent). Shows overlay while dragging, reads dropped image files as base64 ImageAttachment objects

Closes #18

## Test plan
- [ ] Trigger a plan with multiple entries, verify all spinners resolve on completion
- [ ] Trigger prompt-too-long fallback, verify UI switches to chat panel
- [ ] Drag an image file onto the agent chat - overlay should appear, file should attach
- [ ] Drag a non-image file - should be silently ignored
- [ ] Drop multiple images - all should attach

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com