### PR TITLE
fix: support non-localhost runtime — UUID fallback and CORS proxy detection

### DIFF
--- a/src/components/chat/ChatContent.tsx
+++ b/src/components/chat/ChatContent.tsx
@@ -20,6 +20,7 @@ import { getCompletions, parseCommand } from "@/lib/commands/parser";
 import type { CommandContext } from "@/lib/commands/types";
 import { collapseDirectoryListings } from "@/lib/directory-listing";
 import { openExternalLink } from "@/lib/external-link";
+import { generateId } from "@/lib/uuid";
 import { pickAndReadImages } from "@/lib/images/attachments";
 import type { ImageAttachment } from "@/lib/providers/types";
 import { escapeHtmlWithLinks, renderMarkdown } from "@/lib/render-markdown";
@@ -474,7 +475,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     images?: ImageAttachment[],
   ) => {
     const userMessage: Message = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       role: "user",
       content: messageContent,
       images,
@@ -487,7 +488,7 @@ export const ChatContent: Component<ChatContentProps> = (_props) => {
     await chatStore.persistMessage(userMessage);
 
     const context = buildContext();
-    const assistantId = crypto.randomUUID();
+    const assistantId = generateId();
 
     const useTools = areToolsAvailable();
     const session: ActiveStreamingSession = useTools

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -14,6 +14,7 @@ import { VoiceInputButton } from "@/components/chat/VoiceInputButton";
 import { ResizableTextarea } from "@/components/common/ResizableTextarea";
 import { FileTree } from "@/components/sidebar/FileTree";
 import { openExternalLink } from "@/lib/external-link";
+import { generateId } from "@/lib/uuid";
 import {
   loadDirectoryChildren,
   openFileInTab,
@@ -420,7 +421,7 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
     if (!trimmed) return;
 
     const userMessage: Message = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       role: "user",
       content: trimmed,
       timestamp: Date.now(),
@@ -432,7 +433,7 @@ export const ChatPanel: Component<ChatPanelProps> = (_props) => {
     await chatStore.persistMessage(userMessage);
 
     const context = buildContext();
-    const assistantId = crypto.randomUUID();
+    const assistantId = generateId();
 
     // Use tool-aware streaming if tools are available (Seren provider)
     const useTools = areToolsAvailable();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,8 +9,9 @@
  */
 function resolveApiBase(): string {
   if (import.meta.env.VITE_SEREN_API_URL) return import.meta.env.VITE_SEREN_API_URL;
-  // When served from the runtime, proxy through it to avoid CORS
-  if (typeof window !== "undefined" && window.location.hostname === "127.0.0.1") {
+  // When served from the runtime (any host — localhost or LAN IP), proxy
+  // through it to bypass browser CORS restrictions against api.serendb.com.
+  if (typeof window !== "undefined" && window.location.port === "19420") {
     return `${window.location.origin}/api`;
   }
   return "https://api.serendb.com";

--- a/src/lib/rate-limit-fallback.ts
+++ b/src/lib/rate-limit-fallback.ts
@@ -4,6 +4,7 @@
 import type { AgentType } from "@/services/acp";
 import type { AgentMessage } from "@/stores/acp.store";
 import type { Message } from "@/services/chat";
+import { generateId } from "@/lib/uuid";
 
 /** Patterns that indicate an agent has hit a rate limit. */
 const RATE_LIMIT_PATTERNS = [
@@ -191,7 +192,7 @@ export function buildRedirectMessage(
       : `${agentName} agent hit its rate limit.`;
 
   return {
-    id: crypto.randomUUID(),
+    id: generateId(),
     role: "system",
     content:
       `${reasonText} ` +

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Secure UUID v4 generator that works in non-secure HTTP contexts.
+// ABOUTME: Falls back to crypto.getRandomValues when crypto.randomUUID is unavailable.
+
+/**
+ * Generate a UUID v4 string.
+ * Uses crypto.randomUUID() in secure contexts (HTTPS / localhost),
+ * falls back to crypto.getRandomValues() over plain HTTP (e.g. LAN IP).
+ */
+export function generateId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback: build UUID v4 from getRandomValues (available in all browsers)
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // Set version (4) and variant (RFC 4122)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -6,7 +6,7 @@ import { mcpClient } from "@/lib/mcp/client";
 import type { McpTool, McpToolResult } from "@/lib/mcp/types";
 
 const MCP_GATEWAY_URL =
-  typeof window !== "undefined" && window.location.hostname === "127.0.0.1"
+  typeof window !== "undefined" && window.location.port === "19420"
     ? `${window.location.origin}/mcp/mcp`
     : "https://mcp.serendb.com/mcp";
 const SEREN_MCP_SERVER_NAME = "seren-gateway";

--- a/src/services/mcp-oauth.ts
+++ b/src/services/mcp-oauth.ts
@@ -5,7 +5,7 @@ import { isRuntimeConnected, runtimeInvoke } from "@/lib/bridge";
 import { appFetch } from "@/lib/fetch";
 
 const MCP_OAUTH_BASE =
-  typeof window !== "undefined" && window.location.hostname === "127.0.0.1"
+  typeof window !== "undefined" && window.location.port === "19420"
     ? `${window.location.origin}/mcp`
     : "https://mcp.serendb.com";
 // MCP server uses dynamic client registration

--- a/src/stores/acp.store.ts
+++ b/src/stores/acp.store.ts
@@ -8,6 +8,7 @@ import {
   isRateLimitError,
   performAgentFallback,
 } from "@/lib/rate-limit-fallback";
+import { generateId } from "@/lib/uuid";
 
 type UnlistenFn = () => void;
 
@@ -630,7 +631,7 @@ export const acpStore = {
 
     // Add user message
     const userMessage: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "user",
       content: prompt,
       timestamp: Date.now(),
@@ -719,7 +720,7 @@ export const acpStore = {
 
             // Show recovery indicator so the user knows what happened
             const recoveryMsg: AgentMessage = {
-              id: crypto.randomUUID(),
+              id: generateId(),
               type: "assistant",
               content:
                 "Agent session restarted due to inactivity timeout. Retrying your message...",
@@ -1190,7 +1191,7 @@ Summary:`;
           // User-initiated cancellation: record in chat history but don't
           // show the persistent error banner (it's not a real error).
           const cancelMsg: AgentMessage = {
-            id: crypto.randomUUID(),
+            id: generateId(),
             type: "error",
             content: event.data.error,
             timestamp: Date.now(),
@@ -1232,7 +1233,7 @@ Summary:`;
           // Add error message to notify user
           if (timedOutPermissions.length > 0) {
             const timeoutMsg: AgentMessage = {
-              id: crypto.randomUUID(),
+              id: generateId(),
               type: "error",
               content:
                 "Permission request timed out after 5 minutes. " +
@@ -1366,7 +1367,7 @@ Summary:`;
     // Flush accumulated streaming content so tool cards appear in correct chronological order
     if (session.streamingThinking) {
       const thinkingMsg: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "thought",
         content: session.streamingThinking,
         timestamp: Date.now(),
@@ -1379,7 +1380,7 @@ Summary:`;
     }
     if (session.streamingContent) {
       const contentMsg: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "assistant",
         content: session.streamingContent,
         timestamp: Date.now(),
@@ -1396,7 +1397,7 @@ Summary:`;
 
     // Add tool call message
     const message: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "tool",
       content: toolCall.title,
       timestamp: Date.now(),
@@ -1430,7 +1431,7 @@ Summary:`;
 
   handleDiff(sessionId: string, diff: DiffEvent) {
     const message: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "diff",
       content: `Modified: ${diff.path}`,
       timestamp: Date.now(),
@@ -1475,7 +1476,7 @@ Summary:`;
     // Finalize thinking content if any
     if (session.streamingThinking) {
       const thinkingMessage: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "thought",
         content: session.streamingThinking,
         timestamp: Date.now(),
@@ -1495,7 +1496,7 @@ Summary:`;
         : undefined;
 
       const message: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "assistant",
         content: session.streamingContent,
         timestamp: Date.now(),
@@ -1529,7 +1530,7 @@ Summary:`;
 
   addErrorMessage(sessionId: string, error: string) {
     const message: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "error",
       content: error,
       timestamp: Date.now(),

--- a/src/stores/agent.store.ts
+++ b/src/stores/agent.store.ts
@@ -20,6 +20,7 @@ import {
   setAgentConversationTitle as setAgentConversationTitleDb,
 } from "@/lib/bridge";
 import { isLikelyAuthError } from "@/lib/auth-errors";
+import { generateId } from "@/lib/uuid";
 import { refreshAccessToken } from "@/services/auth";
 import {
   isPromptTooLongError,
@@ -1592,7 +1593,7 @@ Summary:`;
       setState("sessions", newSessionId, "compactedSummary", compactedSummary);
 
       const compactionNotice: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "assistant",
         content: `Context compacted: ${toCompact.length} earlier messages summarized to keep the session active. The ${toPreserve.length} most recent messages are shown below.`,
         timestamp: Date.now(),
@@ -1813,7 +1814,7 @@ Summary:`;
     setState("sessions", sessionId, "compactRetryAttempted", false);
 
     const userMessage: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "user",
       content: options?.displayContent ?? prompt,
       timestamp: Date.now(),
@@ -1931,7 +1932,7 @@ Summary:`;
                 "[AgentStore] Agent unresponsive after cancel -- spawned fresh session, skipping retry",
               );
               const cancelMsg: AgentMessage = {
-                id: crypto.randomUUID(),
+                id: generateId(),
                 type: "assistant",
                 content: "Session restarted after cancellation.",
                 timestamp: Date.now(),
@@ -1946,7 +1947,7 @@ Summary:`;
               }
             } else {
               const recoveryMsg: AgentMessage = {
-                id: crypto.randomUUID(),
+                id: generateId(),
                 type: "assistant",
                 content:
                   "Agent session restarted due to inactivity timeout. Retrying your message...",
@@ -2494,7 +2495,7 @@ Summary:`;
 
         if (String(event.data.error).includes("Task cancelled")) {
           const cancelMsg: AgentMessage = {
-            id: crypto.randomUUID(),
+            id: generateId(),
             type: "error",
             content: event.data.error,
             timestamp: Date.now(),
@@ -2535,7 +2536,7 @@ Summary:`;
 
           if (timedOutPermissions.length > 0) {
             const timeoutMsg: AgentMessage = {
-              id: crypto.randomUUID(),
+              id: generateId(),
               type: "error",
               content:
                 "Permission request timed out after 5 minutes. " +
@@ -2660,7 +2661,7 @@ Summary:`;
     }
 
     const userMsg: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "user",
       content: session.pendingUserMessage,
       timestamp: session.pendingUserMessageTimestamp ?? Date.now(),
@@ -2780,7 +2781,7 @@ Summary:`;
     flushChunkBuf(sessionId);
     if (session.streamingThinking) {
       const thinkingMsg: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "thought",
         content: session.streamingThinking,
         timestamp: session.streamingThinkingTimestamp ?? Date.now(),
@@ -2796,7 +2797,7 @@ Summary:`;
     }
     if (session.streamingContent) {
       const contentMsg: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "assistant",
         content: session.streamingContent,
         timestamp: session.streamingContentTimestamp ?? Date.now(),
@@ -2818,7 +2819,7 @@ Summary:`;
     session.pendingToolCalls.set(toolCall.toolCallId, toolCall);
 
     const message: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "tool",
       content: toolCall.title,
       timestamp: Date.now(),
@@ -2914,7 +2915,7 @@ Summary:`;
     if (session.skipHistoryReplay) return;
 
     const nextMessage: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "diff",
       content: `Modified: ${diff.path}`,
       timestamp: Date.now(),
@@ -3034,7 +3035,7 @@ Summary:`;
 
     if (session.streamingThinking) {
       const thinkingMessage: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "thought",
         content: session.streamingThinking,
         timestamp: session.streamingThinkingTimestamp ?? Date.now(),
@@ -3068,7 +3069,7 @@ Summary:`;
         : undefined;
 
       const message: AgentMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         type: "assistant",
         content: session.streamingContent,
         timestamp: session.streamingContentTimestamp ?? Date.now(),
@@ -3173,7 +3174,7 @@ Summary:`;
         buildForkBootstrapContext(session, forkedMessages) ?? undefined;
     }
 
-    const newConversationId = crypto.randomUUID();
+    const newConversationId = generateId();
     const forkTitle = `Fork of ${session.title ?? "Agent"}`;
     try {
       await createAgentConversation(
@@ -3223,7 +3224,7 @@ Summary:`;
     const prefixedError = `[${agentLabel}] ${error}`;
 
     const message: AgentMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       type: "error",
       content: prefixedError,
       timestamp: Date.now(),

--- a/src/stores/chat.store.ts
+++ b/src/stores/chat.store.ts
@@ -14,6 +14,7 @@ import {
   updateConversation as updateConversationDb,
 } from "@/lib/bridge";
 import type { ProviderId } from "@/lib/providers/types";
+import { generateId } from "@/lib/uuid";
 import {
   estimateConversationTokens,
   getModelContextLimit,
@@ -226,7 +227,7 @@ export const chatStore = {
    * Create a new conversation and switch to it.
    */
   async createConversation(title = "New Chat"): Promise<Conversation> {
-    const id = crypto.randomUUID();
+    const id = generateId();
     const model = state.selectedModel;
     const provider = null; // Will be determined from model
 
@@ -620,7 +621,7 @@ Summary:`;
     const conversation = await this.createConversation(title);
 
     const userMessage: Message = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       role: "user",
       content: initialMessage,
       timestamp: Date.now(),

--- a/src/stores/conversation.store.ts
+++ b/src/stores/conversation.store.ts
@@ -14,6 +14,7 @@ import {
   saveMessage as saveMessageDb,
   updateConversation as updateConversationDb,
 } from "@/lib/bridge";
+import { generateId } from "@/lib/uuid";
 import type { UnifiedMessage } from "@/types/conversation";
 import { deserializeMetadata, serializeMetadata } from "@/types/conversation";
 
@@ -139,7 +140,7 @@ export const conversationStore = {
     model: string,
     projectRoot?: string,
   ): Promise<Conversation> {
-    const id = crypto.randomUUID();
+    const id = generateId();
 
     try {
       await createConversationDb(id, title, model, undefined, projectRoot);

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -1,4 +1,5 @@
 import { createStore } from "solid-js/store";
+import { generateId } from "@/lib/uuid";
 
 export interface Tab {
   id: string;
@@ -28,7 +29,7 @@ export function openTab(filePath: string, content: string = ""): string {
     return existing.id;
   }
 
-  const id = crypto.randomUUID();
+  const id = generateId();
   const fileName = filePath.split("/").pop() || filePath;
 
   setTabsState("tabs", (tabs) => [

--- a/tests/lib/uuid.test.ts
+++ b/tests/lib/uuid.test.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Tests for UUID generation that works in non-secure HTTP contexts.
+// ABOUTME: Validates format, uniqueness, and fallback when crypto.randomUUID is unavailable.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { generateId } from "@/lib/uuid";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generateId", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a valid UUID v4 string", () => {
+    expect(generateId()).toMatch(UUID_RE);
+  });
+
+  it("returns unique values on successive calls", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => generateId()));
+    expect(ids.size).toBe(50);
+  });
+
+  it("falls back to getRandomValues when randomUUID is unavailable", () => {
+    // Simulate non-secure context: randomUUID is undefined
+    const original = crypto.randomUUID;
+    vi.stubGlobal("crypto", { ...crypto, randomUUID: undefined, getRandomValues: crypto.getRandomValues.bind(crypto) });
+
+    const id = generateId();
+    expect(id).toMatch(UUID_RE);
+
+    vi.stubGlobal("crypto", { ...crypto, randomUUID: original });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `generateId()` utility (`src/lib/uuid.ts`) that uses `crypto.randomUUID()` in secure contexts and falls back to `crypto.getRandomValues()` over plain HTTP
- Replaces all 35 `crypto.randomUUID()` call sites across 8 files
- Fixes proxy detection in `config.ts`, `mcp-gateway.ts`, and `mcp-oauth.ts`: changes `hostname === "127.0.0.1"` to `port === "19420"` so the runtime proxy works from any host

Closes #24

## Test plan

- [x] `generateId()` unit tests: valid UUID v4 format, uniqueness, fallback when randomUUID unavailable
- [x] SPA build passes (`pnpm run build`)
- [x] Zero remaining `crypto.randomUUID()` calls outside `uuid.ts`
- [x] Zero remaining `hostname === "127.0.0.1"` proxy checks

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com