### PR TITLE
fix: enable remote access -- inject token via HTML, detect runtime via meta tag

### DIFF
--- a/runtime/src/server.ts
+++ b/runtime/src/server.ts
@@ -100,17 +100,18 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 /**
- * Serve the index.html with the build hash injected as a meta tag.
- * This allows the SPA to detect stale cached versions and auto-reload.
+ * Serve the index.html with runtime metadata injected as meta tags.
+ * - seren-build-hash: lets the SPA detect stale cache and auto-reload
+ * - seren-runtime-token: auth token for WebSocket, delivered same-origin
+ *   (no /health fetch needed — works for remote access too)
  */
 function serveHtml(res: import("node:http").ServerResponse): boolean {
   const indexPath = join(PUBLIC_DIR, "index.html");
   try {
     let html = readFileSync(indexPath, "utf-8");
-    // Inject build hash so the SPA can detect stale cache
     html = html.replace(
       "<head>",
-      `<head><meta name="seren-build-hash" content="${BUILD_HASH}">`,
+      `<head><meta name="seren-build-hash" content="${BUILD_HASH}"><meta name="seren-runtime-token" content="${AUTH_TOKEN}">`,
     );
     res.writeHead(200, {
       "Content-Type": "text/html; charset=utf-8",

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -78,10 +78,31 @@ const DB_VERSION = 1;
 const CONVERSATIONS_STORE = "conversations";
 const MESSAGES_STORE = "messages";
 
-const RUNTIME_PORT = 19420;
-const RUNTIME_HTTP_URL = `http://127.0.0.1:${RUNTIME_PORT}`;
-const RUNTIME_WS_URL = `ws://127.0.0.1:${RUNTIME_PORT}`;
 const RPC_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolve the runtime HTTP and WS URLs.
+ * When served by the runtime, use the same origin (works for any host/port).
+ * Otherwise fall back to localhost:19420 for dev/CDN scenarios.
+ */
+function resolveRuntimeUrls(): { http: string; ws: string } {
+  if (typeof window !== "undefined") {
+    // Check for runtime-injected meta tag (definitive detection)
+    const meta = document.querySelector('meta[name="seren-runtime-token"]');
+    if (meta) {
+      const origin = window.location.origin;
+      const wsProto = window.location.protocol === "https:" ? "wss:" : "ws:";
+      return {
+        http: origin,
+        ws: `${wsProto}//${window.location.host}`,
+      };
+    }
+  }
+  // Fallback for dev server or CDN-hosted SPA
+  return { http: "http://127.0.0.1:19420", ws: "ws://127.0.0.1:19420" };
+}
+
+const { http: RUNTIME_HTTP_URL, ws: RUNTIME_WS_URL } = resolveRuntimeUrls();
 
 // ============================================================================
 // Runtime connection (WebSocket JSON-RPC with token auth)
@@ -137,35 +158,65 @@ function getEmbeddedBuildHash(): string | null {
 }
 
 /**
- * Fetch the auth token from the runtime's health endpoint.
- * Also checks the server's build hash against the SPA's embedded version.
- * If they don't match, the SPA is stale and we force a hard reload.
+ * Get the auth token for the runtime WebSocket connection.
+ *
+ * Primary: read from `<meta name="seren-runtime-token">` injected by the
+ * runtime into served HTML. This works for any host/port (remote or local).
+ *
+ * Fallback: fetch from /health endpoint (dev server scenario where the SPA
+ * is served by Vite but the runtime is running separately on localhost).
  */
 async function fetchRuntimeToken(): Promise<string | null> {
+  // Primary: meta tag (same-origin, no network request)
+  const meta = document.querySelector('meta[name="seren-runtime-token"]');
+  const metaToken = meta?.getAttribute("content") ?? null;
+  if (metaToken) {
+    // Still check for stale SPA via build hash
+    await checkStaleSpa();
+    return metaToken;
+  }
+
+  // Fallback: /health endpoint (dev mode — SPA on Vite, runtime on localhost)
   try {
     const res = await fetch(`${RUNTIME_HTTP_URL}/health`);
     if (!res.ok) return null;
     const data = await res.json();
-
-    // Detect stale SPA: compare server build hash with what's in our HTML
-    const embeddedHash = getEmbeddedBuildHash();
-    if (data.buildHash && embeddedHash && data.buildHash !== embeddedHash) {
-      console.log("[Bridge] Stale SPA detected — forcing reload", {
-        server: data.buildHash,
-        embedded: embeddedHash,
-      });
-      // Clear caches and force reload
-      if ("caches" in window) {
-        const keys = await caches.keys();
-        await Promise.all(keys.map((k) => caches.delete(k)));
-      }
-      window.location.reload();
-      return null;
-    }
-
+    await checkStaleSpa(data.buildHash);
     return data.token ?? null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Compare build hashes and force-reload if the SPA is stale.
+ * When called with a server hash, uses that; otherwise fetches from /health.
+ */
+async function checkStaleSpa(serverHash?: string): Promise<void> {
+  const embeddedHash = getEmbeddedBuildHash();
+  if (!embeddedHash) return;
+
+  let remoteHash = serverHash;
+  if (!remoteHash) {
+    try {
+      const res = await fetch(`${RUNTIME_HTTP_URL}/health`);
+      if (res.ok) {
+        const data = await res.json();
+        remoteHash = data.buildHash;
+      }
+    } catch { /* ignore */ }
+  }
+
+  if (remoteHash && remoteHash !== embeddedHash) {
+    console.log("[Bridge] Stale SPA detected — forcing reload", {
+      server: remoteHash,
+      embedded: embeddedHash,
+    });
+    if ("caches" in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+    window.location.reload();
   }
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,17 +1,17 @@
 // ABOUTME: Centralized configuration for the Seren Gateway API.
 // ABOUTME: All API calls must use these values for consistency and security.
 
+import { isServedByRuntime } from "@/lib/runtime-detect";
+
 /**
  * Seren Gateway API base URL.
- * When running from the local runtime (localhost:19420), API calls are proxied
- * through the runtime to bypass browser CORS restrictions.
- * NOTE: Seren Gateway API does NOT use a version prefix.
+ * When served by the runtime, API calls are proxied through it to bypass
+ * browser CORS restrictions. Detection uses server-injected meta tag —
+ * works for any host (localhost, LAN IP, custom port).
  */
 function resolveApiBase(): string {
   if (import.meta.env.VITE_SEREN_API_URL) return import.meta.env.VITE_SEREN_API_URL;
-  // When served from the runtime (any host — localhost or LAN IP), proxy
-  // through it to bypass browser CORS restrictions against api.serendb.com.
-  if (typeof window !== "undefined" && window.location.port === "19420") {
+  if (isServedByRuntime()) {
     return `${window.location.origin}/api`;
   }
   return "https://api.serendb.com";

--- a/src/lib/runtime-detect.ts
+++ b/src/lib/runtime-detect.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Definitive runtime detection via server-injected meta tags.
+// ABOUTME: Replaces all hostname/port heuristics for proxy routing and token retrieval.
+
+/**
+ * True when the SPA was served by the Seren Local runtime.
+ * Detection: the runtime injects `<meta name="seren-runtime-token">` into
+ * the HTML at serve time. This is definitive — no hostname or port guessing.
+ */
+export function isServedByRuntime(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.querySelector('meta[name="seren-runtime-token"]') !== null;
+}
+
+/**
+ * Read the auth token injected by the runtime into the served HTML.
+ * Returns null when not served by the runtime (e.g. CDN/dev server).
+ */
+export function getRuntimeToken(): string | null {
+  if (typeof document === "undefined") return null;
+  const meta = document.querySelector('meta[name="seren-runtime-token"]');
+  return meta?.getAttribute("content") ?? null;
+}
+
+/**
+ * The origin (scheme + host + port) of the runtime that served this SPA.
+ * When served by the runtime, this is simply `window.location.origin` —
+ * works for localhost, LAN IP, or any custom port.
+ * Returns null when not served by the runtime.
+ */
+export function getRuntimeOrigin(): string | null {
+  if (!isServedByRuntime()) return null;
+  return window.location.origin;
+}

--- a/src/services/mcp-gateway.ts
+++ b/src/services/mcp-gateway.ts
@@ -4,11 +4,11 @@
 import { getSerenApiKey } from "@/lib/bridge";
 import { mcpClient } from "@/lib/mcp/client";
 import type { McpTool, McpToolResult } from "@/lib/mcp/types";
+import { isServedByRuntime } from "@/lib/runtime-detect";
 
-const MCP_GATEWAY_URL =
-  typeof window !== "undefined" && window.location.port === "19420"
-    ? `${window.location.origin}/mcp/mcp`
-    : "https://mcp.serendb.com/mcp";
+const MCP_GATEWAY_URL = isServedByRuntime()
+  ? `${window.location.origin}/mcp/mcp`
+  : "https://mcp.serendb.com/mcp";
 const SEREN_MCP_SERVER_NAME = "seren-gateway";
 
 // Cache configuration

--- a/src/services/mcp-oauth.ts
+++ b/src/services/mcp-oauth.ts
@@ -3,11 +3,11 @@
 
 import { isRuntimeConnected, runtimeInvoke } from "@/lib/bridge";
 import { appFetch } from "@/lib/fetch";
+import { isServedByRuntime } from "@/lib/runtime-detect";
 
-const MCP_OAUTH_BASE =
-  typeof window !== "undefined" && window.location.port === "19420"
-    ? `${window.location.origin}/mcp`
-    : "https://mcp.serendb.com";
+const MCP_OAUTH_BASE = isServedByRuntime()
+  ? `${window.location.origin}/mcp`
+  : "https://mcp.serendb.com";
 // MCP server uses dynamic client registration
 const MCP_CLIENT_NAME = "Seren Desktop";
 // Use loopback redirect - webviews can intercept HTTP navigations but not custom schemes

--- a/tests/lib/runtime-detect.test.ts
+++ b/tests/lib/runtime-detect.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Tests for runtime detection via server-injected meta tags.
+// ABOUTME: Validates detection, token extraction, and origin resolution.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  isServedByRuntime,
+  getRuntimeToken,
+  getRuntimeOrigin,
+} from "@/lib/runtime-detect";
+
+function injectMeta(name: string, content: string): HTMLMetaElement {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", name);
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+  return meta;
+}
+
+let injected: HTMLMetaElement[] = [];
+
+beforeEach(() => {
+  injected = [];
+});
+
+afterEach(() => {
+  for (const el of injected) el.remove();
+  injected = [];
+});
+
+describe("isServedByRuntime", () => {
+  it("returns false when no meta tag present", () => {
+    expect(isServedByRuntime()).toBe(false);
+  });
+
+  it("returns true when seren-runtime-token meta tag present", () => {
+    injected.push(injectMeta("seren-runtime-token", "abc123"));
+    expect(isServedByRuntime()).toBe(true);
+  });
+});
+
+describe("getRuntimeToken", () => {
+  it("returns null when no meta tag present", () => {
+    expect(getRuntimeToken()).toBeNull();
+  });
+
+  it("returns token value from meta tag", () => {
+    injected.push(injectMeta("seren-runtime-token", "secret-token-xyz"));
+    expect(getRuntimeToken()).toBe("secret-token-xyz");
+  });
+});
+
+describe("getRuntimeOrigin", () => {
+  it("returns null when not served by runtime", () => {
+    expect(getRuntimeOrigin()).toBeNull();
+  });
+
+  it("returns window.location.origin when served by runtime", () => {
+    injected.push(injectMeta("seren-runtime-token", "tok"));
+    // In jsdom/happy-dom, window.location.origin is "http://localhost:3000" or similar
+    expect(getRuntimeOrigin()).toBe(window.location.origin);
+  });
+});


### PR DESCRIPTION
## Summary

- Runtime injects auth token into served HTML as `<meta name="seren-runtime-token">` -- SPA reads it directly, no `/health` fetch needed
- `bridge.ts` uses `window.location.origin` for HTTP/WS URLs when served by the runtime (was hardcoded `127.0.0.1`)
- New `src/lib/runtime-detect.ts` provides `isServedByRuntime()`, `getRuntimeToken()`, `getRuntimeOrigin()` -- replaces all hostname/port heuristics
- `config.ts`, `mcp-gateway.ts`, `mcp-oauth.ts` now use `isServedByRuntime()` instead of `port === "19420"`
- `/health` keeps loopback-only token gating for defense in depth

Closes #26

## Test plan

- [x] `runtime-detect` unit tests: meta tag detection, token extraction, origin resolution
- [x] SPA build passes
- [x] Runtime build passes
- [x] All 70 runtime tests pass
- [x] No remaining port/hostname heuristics in proxy detection

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com