### PR TITLE
fix: handle SSE responses in MCP client, silence memory sync 404

### DIFF
--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -406,7 +406,30 @@ function createMcpClient() {
       throw new Error(`MCP HTTP error ${response.status}: ${text}`);
     }
 
-    const data = await response.json();
+    // Handle SSE responses: the server may respond with text/event-stream
+    // when the Accept header includes it. Parse SSE to extract the JSON-RPC result.
+    const contentType = response.headers.get("Content-Type") ?? "";
+    let data: { error?: { message?: string }; result?: unknown };
+
+    if (contentType.includes("text/event-stream")) {
+      const text = await response.text();
+      // Extract the last `data:` line that contains the JSON-RPC response
+      const lines = text.split("\n");
+      let lastData: string | null = null;
+      for (const line of lines) {
+        if (line.startsWith("data:")) {
+          const payload = line.slice(5).trim();
+          if (payload && payload !== "[DONE]") lastData = payload;
+        }
+      }
+      if (!lastData) {
+        throw new Error("MCP SSE response contained no data");
+      }
+      data = JSON.parse(lastData);
+    } else {
+      data = await response.json();
+    }
+
     if (data.error) {
       throw new Error(data.error.message || "MCP RPC error");
     }

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -129,8 +129,8 @@ export async function syncMemories(): Promise<SyncResult | null> {
     if (!resp.ok) return null;
     const json = await resp.json();
     return json.data ?? null;
-  } catch (error) {
-    console.warn("[Memory] Failed to sync memories:", error);
+  } catch {
+    // Memory sync is best-effort — endpoint may not exist yet
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- MCP client now checks `Content-Type` response header before parsing: SSE (`text/event-stream`) is parsed by extracting `data:` lines, JSON is parsed directly
- Memory sync silences the 404 warning (best-effort call to an endpoint that may not exist yet)

Closes #32

## Test plan

- [x] SPA build passes (414 modules, 0 errors)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
