### PR TITLE
fix: load available skills in sidebar search (#36)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -62,7 +62,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
 
   onMount(() => {
     document.addEventListener("mousedown", handleClickOutside);
-    void skillsStore.refreshInstalled();
+    void skillsStore.refresh();
   });
 
   onCleanup(() => {


### PR DESCRIPTION
## Summary
- **Root cause**: `ThreadSidebar.onMount` only called `skillsStore.refreshInstalled()`, never `refreshAvailable()`. The sidebar search combines installed + available skills, but available was always `[]`.
- **Fix**: Changed to `skillsStore.refresh()` which loads both installed and available skills, making marketplace skills searchable from the sidebar.

Closes #36

## Test plan
- [ ] Open seren-local, type a query (e.g. "poly") in the sidebar skills search
- [ ] Verify matching marketplace/catalog skills appear in results
- [ ] Verify installed skills still appear correctly
- [ ] Verify "N active" count still reflects thread-active skills when no query

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com