### PR TITLE
fix: sidebar skills loading state and isLoading race (#36)

### DIFF
--- a/src/components/layout/ThreadSidebar.tsx
+++ b/src/components/layout/ThreadSidebar.tsx
@@ -40,6 +40,7 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
   const [spawning, setSpawning] = createSignal(false);
   const [showCreateMenu, setShowCreateMenu] = createSignal(false);
   const [showCatalog, setShowCatalog] = createSignal(false);
+  const [skillsReady, setSkillsReady] = createSignal(false);
   let launcherRef: HTMLDivElement | undefined;
   let searchInputRef: HTMLInputElement | undefined;
 
@@ -62,7 +63,10 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
 
   onMount(() => {
     document.addEventListener("mousedown", handleClickOutside);
-    void skillsStore.refresh();
+    skillsStore.refresh().then(
+      () => setSkillsReady(true),
+      () => setSkillsReady(true),
+    );
   });
 
   onCleanup(() => {
@@ -694,7 +698,9 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
                     Back to skills
                   </button>
                   <span class="text-[11px] text-muted-foreground/50">
-                    {skillsStore.available.length} available
+                    {skillsReady()
+                      ? `${skillsStore.available.length} available`
+                      : "Loading catalog..."}
                   </span>
                 </div>
                 <div class="max-h-[300px] overflow-y-auto">
@@ -755,12 +761,19 @@ export const ThreadSidebar: Component<ThreadSidebarProps> = (props) => {
             {/* Skills list — active thread skills */}
             <Show when={!showCatalog()}>
               <div class="mt-2 max-h-[300px] overflow-y-auto">
+                <Show when={!skillsReady() && launcherQuery().trim()}>
+                  <div class="w-full px-3 py-4 text-[13px] text-center text-muted-foreground">
+                    Loading skills catalog...
+                  </div>
+                </Show>
                 <Show
                   when={filteredSkills().length > 0}
                   fallback={
-                    <div class="w-full px-3 py-4 text-[13px] text-center text-muted-foreground">
-                      No matching skills
-                    </div>
+                    <Show when={skillsReady()}>
+                      <div class="w-full px-3 py-4 text-[13px] text-center text-muted-foreground">
+                        {launcherQuery().trim() ? "No matching skills" : "No active skills"}
+                      </div>
+                    </Show>
                   }
                 >
                   <For each={filteredSkills()}>

--- a/src/stores/skills.store.ts
+++ b/src/stores/skills.store.ts
@@ -587,9 +587,6 @@ export const skillsStore = {
    * Pass skipCache=true to bypass the localStorage cache (e.g. user-triggered refresh).
    */
   async refreshAvailable(skipCache = false): Promise<void> {
-    setState("isLoading", true);
-    setState("error", null);
-
     try {
       const available = await skills.fetchAllSkills(skipCache);
       setState("available", available);
@@ -599,8 +596,6 @@ export const skillsStore = {
         err instanceof Error ? err.message : "Failed to load skills";
       setState("error", message);
       console.error("[SkillsStore] Error loading available skills:", err);
-    } finally {
-      setState("isLoading", false);
     }
   },
 
@@ -608,9 +603,6 @@ export const skillsStore = {
    * Refresh installed skills from the file system.
    */
   async refreshInstalled(): Promise<void> {
-    setState("isLoading", true);
-    setState("error", null);
-
     try {
       const fileTree = getFileTreeState();
       const projectRoot = fileTree.rootPath;
@@ -629,8 +621,6 @@ export const skillsStore = {
         err instanceof Error ? err.message : "Failed to load installed skills";
       setState("error", message);
       console.error("[SkillsStore] Error loading installed skills:", err);
-    } finally {
-      setState("isLoading", false);
     }
   },
 
@@ -662,6 +652,9 @@ export const skillsStore = {
       failed: 0,
     };
 
+    setState("isLoading", true);
+    setState("error", null);
+    try {
     await Promise.all([
       this.refreshAvailable(skipCache),
       this.refreshInstalled(),
@@ -820,6 +813,9 @@ export const skillsStore = {
     }
 
     return summary;
+    } finally {
+      setState("isLoading", false);
+    }
   },
 
   /**
@@ -916,8 +912,14 @@ export const skillsStore = {
    * Clear the skills index cache and refresh.
    */
   async clearCacheAndRefresh(): Promise<void> {
-    skills.clearCache();
-    await this.refreshAvailable();
+    setState("isLoading", true);
+    setState("error", null);
+    try {
+      skills.clearCache();
+      await this.refreshAvailable();
+    } finally {
+      setState("isLoading", false);
+    }
   },
 
   hideSkill(slug: string): void {


### PR DESCRIPTION
## Summary
- **Loading indicator**: Sidebar now shows "Loading skills catalog..." while the async fetch of 67+ skills from GitHub + catalog API is in progress, instead of misleading "No matching skills"
- **isLoading race fix**: `refreshAvailable()` and `refreshInstalled()` run in parallel via `Promise.all` — previously each independently toggled `isLoading`, so whichever finished first prematurely cleared the flag. Moved `isLoading` management to `_refreshInner()` which owns both operations.
- **Better empty state**: Shows "No active skills" when no search query and no thread skills, vs "No matching skills" which implies a failed search

Closes #36

## Test plan
- [ ] Open seren-local, observe "Loading skills catalog..." while typing a search query before skills finish loading
- [ ] After loading completes, search for "poly" — verify 7+ polymarket skills appear
- [ ] With no search query, verify "N active" shows correct count for thread skills
- [ ] Click refresh button — verify loading state shows during cache-busted refetch

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com