### PR TITLE
fix: crypto.subtle fallback for non-secure HTTP contexts

### DIFF
--- a/src/lib/sha256.ts
+++ b/src/lib/sha256.ts
@@ -1,0 +1,103 @@
+// ABOUTME: SHA-256 hash utility that works in non-secure HTTP contexts.
+// ABOUTME: Uses crypto.subtle when available, falls back to pure-JS implementation.
+
+/**
+ * Compute SHA-256 hex digest of a string.
+ * Uses Web Crypto API in secure contexts, pure-JS fallback over plain HTTP.
+ */
+export async function sha256(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+
+  if (typeof crypto !== "undefined" && crypto.subtle) {
+    const buf = await crypto.subtle.digest("SHA-256", data);
+    return hexFromBuffer(new Uint8Array(buf));
+  }
+
+  // Fallback: pure-JS SHA-256 for non-secure contexts (LAN IP over HTTP)
+  return sha256Fallback(data);
+}
+
+function hexFromBuffer(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// ── Pure-JS SHA-256 (RFC 6234) ──────────────────────────────────────
+
+const K = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+  0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+  0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+  0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+  0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+  0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+  0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);
+
+function rotr(n: number, x: number): number {
+  return (x >>> n) | (x << (32 - n));
+}
+
+function sha256Fallback(data: Uint8Array): string {
+  // Pre-processing: padding
+  const bitLen = data.length * 8;
+  const padLen = (data.length + 9 + 63) & ~63;
+  const padded = new Uint8Array(padLen);
+  padded.set(data);
+  padded[data.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(padLen - 4, bitLen, false);
+
+  let h0 = 0x6a09e667;
+  let h1 = 0xbb67ae85;
+  let h2 = 0x3c6ef372;
+  let h3 = 0xa54ff53a;
+  let h4 = 0x510e527f;
+  let h5 = 0x9b05688c;
+  let h6 = 0x1f83d9ab;
+  let h7 = 0x5be0cd19;
+
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < padLen; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getUint32(offset + i * 4, false);
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(7, w[i - 15]) ^ rotr(18, w[i - 15]) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(17, w[i - 2]) ^ rotr(19, w[i - 2]) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0;
+    }
+
+    let a = h0, b = h1, c = h2, d = h3, e = h4, f = h5, g = h6, h = h7;
+
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(6, e) ^ rotr(11, e) ^ rotr(25, e);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) >>> 0;
+      const S0 = rotr(2, a) ^ rotr(13, a) ^ rotr(22, a);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) >>> 0;
+
+      h = g; g = f; f = e; e = (d + temp1) >>> 0;
+      d = c; c = b; b = a; a = (temp1 + temp2) >>> 0;
+    }
+
+    h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0;
+    h2 = (h2 + c) >>> 0; h3 = (h3 + d) >>> 0;
+    h4 = (h4 + e) >>> 0; h5 = (h5 + f) >>> 0;
+    h6 = (h6 + g) >>> 0; h7 = (h7 + h) >>> 0;
+  }
+
+  const result = new Uint8Array(32);
+  const rv = new DataView(result.buffer);
+  rv.setUint32(0, h0); rv.setUint32(4, h1);
+  rv.setUint32(8, h2); rv.setUint32(12, h3);
+  rv.setUint32(16, h4); rv.setUint32(20, h5);
+  rv.setUint32(24, h6); rv.setUint32(28, h7);
+
+  return hexFromBuffer(result);
+}

--- a/src/lib/skills/parser.ts
+++ b/src/lib/skills/parser.ts
@@ -293,9 +293,6 @@ function extractDescriptionFromContent(content: string): string | null {
  * Compute SHA-256 hash of content for change detection.
  */
 export async function computeContentHash(content: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(content);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  const { sha256 } = await import("@/lib/sha256");
+  return sha256(content);
 }

--- a/src/services/mcp-oauth.ts
+++ b/src/services/mcp-oauth.ts
@@ -95,12 +95,19 @@ function generateCodeVerifier(): string {
  * Generate PKCE code challenge from verifier using S256.
  */
 async function generateCodeChallenge(verifier: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(verifier);
-  const hash = await crypto.subtle.digest("SHA-256", data);
+  const data = new TextEncoder().encode(verifier);
+  let hashBytes: Uint8Array;
 
-  // Base64url encode (no padding)
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(hash)));
+  if (typeof crypto !== "undefined" && crypto.subtle) {
+    const buf = await crypto.subtle.digest("SHA-256", data);
+    hashBytes = new Uint8Array(buf);
+  } else {
+    const { sha256 } = await import("@/lib/sha256");
+    const hex = await sha256(verifier);
+    hashBytes = new Uint8Array(hex.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+  }
+
+  const base64 = btoa(String.fromCharCode(...hashBytes));
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 

--- a/src/services/oauth.ts
+++ b/src/services/oauth.ts
@@ -48,11 +48,20 @@ function generateRandomString(length: number): string {
  * Generate PKCE code challenge from verifier.
  */
 async function generateCodeChallenge(verifier: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(verifier);
-  const hash = await crypto.subtle.digest("SHA-256", data);
-  // Base64url encode the hash
-  const base64 = btoa(String.fromCharCode(...new Uint8Array(hash)));
+  const data = new TextEncoder().encode(verifier);
+  let hashBytes: Uint8Array;
+
+  if (typeof crypto !== "undefined" && crypto.subtle) {
+    const buf = await crypto.subtle.digest("SHA-256", data);
+    hashBytes = new Uint8Array(buf);
+  } else {
+    // Non-secure context fallback
+    const { sha256 } = await import("@/lib/sha256");
+    const hex = await sha256(verifier);
+    hashBytes = new Uint8Array(hex.match(/.{2}/g)!.map((b) => parseInt(b, 16)));
+  }
+
+  const base64 = btoa(String.fromCharCode(...hashBytes));
   return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 

--- a/tests/lib/sha256.test.ts
+++ b/tests/lib/sha256.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Tests for SHA-256 utility with non-secure context fallback.
+// ABOUTME: Validates correct hash output and fallback when crypto.subtle is unavailable.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { sha256 } from "@/lib/sha256";
+
+describe("sha256", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("produces correct SHA-256 hex for empty string", async () => {
+    const hash = await sha256("");
+    expect(hash).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    );
+  });
+
+  it("produces correct SHA-256 hex for 'hello'", async () => {
+    const hash = await sha256("hello");
+    expect(hash).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+
+  it("produces correct hash when crypto.subtle is unavailable", async () => {
+    // Simulate non-secure context
+    vi.stubGlobal("crypto", {
+      ...crypto,
+      subtle: undefined,
+      getRandomValues: crypto.getRandomValues.bind(crypto),
+    });
+
+    const hash = await sha256("hello");
+    expect(hash).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+
+  it("returns 64-character hex string", async () => {
+    const hash = await sha256("test content");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/lib/sha256.ts`: SHA-256 utility with `crypto.subtle` primary path and pure-JS RFC 6234 fallback
- Fixed 3 crash sites: `parser.ts:computeContentHash`, `oauth.ts:generateCodeChallenge`, `mcp-oauth.ts:generateCodeChallenge`
- Full audit confirmed no remaining `crypto.subtle` or `crypto.randomUUID` usage without fallbacks

Closes #45

## Test plan

- [x] SHA-256 produces correct hashes (empty string, "hello")
- [x] Fallback produces identical output when `crypto.subtle` is stubbed as `undefined`
- [x] SPA build passes

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
