### PR TITLE
fix: wire agent buttons — map provider_* to acp_* handlers, call initialize

### DIFF
--- a/runtime/src/handlers/index.ts
+++ b/runtime/src/handlers/index.ts
@@ -34,7 +34,7 @@ export function registerAllHandlers(): void {
   registerHandler("save_file_dialog", dialogs.saveFileDialog);
   registerHandler("reveal_in_file_manager", dialogs.revealInFileManager);
 
-  // ACP agent handlers
+  // ACP agent handlers (acp_* names)
   registerHandler("acp_spawn", acp.acpSpawn);
   registerHandler("acp_prompt", acp.acpPrompt);
   registerHandler("acp_cancel", acp.acpCancel);
@@ -49,6 +49,37 @@ export function registerAllHandlers(): void {
   registerHandler("acp_ensure_codex_cli", acp.acpEnsureCodexCli);
   registerHandler("acp_ensure_agent_cli", acp.acpEnsureAgentCli);
   registerHandler("acp_launch_login", acp.acpLaunchLogin);
+
+  // Provider aliases — providers.ts (ported from desktop) uses provider_* names.
+  // These map 1:1 to the acp_* handlers above.
+  registerHandler("provider_get_available_agents", acp.acpGetAvailableAgents);
+  registerHandler("provider_spawn", acp.acpSpawn);
+  registerHandler("provider_cancel", acp.acpCancel);
+  registerHandler("provider_terminate", acp.acpTerminate);
+  registerHandler("provider_list_sessions", acp.acpListSessions);
+  registerHandler("provider_set_permission_mode", acp.acpSetPermissionMode);
+  registerHandler("provider_respond_to_permission", acp.acpRespondToPermission);
+  registerHandler("provider_respond_to_diff_proposal", acp.acpRespondToDiffProposal);
+  registerHandler("provider_ensure_agent_cli", acp.acpEnsureAgentCli);
+  registerHandler("provider_check_agent_available", acp.acpCheckAgentAvailable);
+  registerHandler("provider_prompt", acp.acpPrompt);
+  registerHandler("provider_launch_login", acp.acpLaunchLogin);
+
+  // Provider commands with no ACP equivalent — stubs that return safe defaults
+  registerHandler("provider_native_fork_session", async (params: { sessionId: string }) => {
+    // Fork creates a new session from an existing one's context.
+    // Not yet implemented — return empty string to indicate no fork created.
+    return "";
+  });
+  registerHandler("provider_list_remote_sessions", async () => {
+    return { sessions: [], nextCursor: null };
+  });
+  registerHandler("provider_set_session_model", async () => {
+    return { ok: true };
+  });
+  registerHandler("provider_update_session_config_option", async () => {
+    return { ok: true };
+  });
 
   // OpenClaw messaging gateway handlers
   registerHandler("openclaw_start", openclaw.openclawStart);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
   logout,
   setAuthenticated,
 } from "@/stores/auth.store";
+import { agentStore } from "@/stores/agent.store";
 import { autocompleteStore } from "@/stores/autocomplete.store";
 import { chatStore } from "@/stores/chat.store";
 import { providerStore } from "@/stores/provider.store";
@@ -74,9 +75,11 @@ function App() {
     }
 
     // Try connecting to local runtime (non-blocking)
-    connectToRuntime().then((connected) => {
+    connectToRuntime().then(async (connected) => {
       if (connected) {
         console.log("[App] Local runtime connected");
+        // Initialize agent store — detects available agents (Claude, Codex)
+        await agentStore.initialize();
       }
     });
 


### PR DESCRIPTION
## Summary

Two bugs prevented Claude Agent and Codex Agent buttons from appearing in the sidebar launcher:

1. **RPC name mismatch:** `providers.ts` calls `provider_*` commands (ported from desktop) but the runtime registers `acp_*` handlers. Added 12 `provider_*` aliases in `index.ts` mapping to existing `acp_*` handlers, plus 4 stub handlers for commands with no ACP equivalent (`native_fork_session`, `list_remote_sessions`, `set_session_model`, `update_session_config_option`).

2. **`agentStore.initialize()` never called:** Desktop calls it in `App.tsx:102` after runtime connects. seren-local never called it, so `availableAgents` stayed as an empty array and the `<Show when={...}>` guards hid all agent buttons. Added the call in `connectToRuntime()` callback.

Closes #47

## Test plan

- [x] SPA build passes
- [x] 70 runtime tests pass
- [x] Manual test: "New Agent" dropdown now shows Seren Agent, Claude Agent, Codex Agent

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
