### PR TITLE
fix: replace dead ACP protocol with direct CLI spawning

### DIFF
--- a/runtime/bin/browser-local/agent-registry.mjs
+++ b/runtime/bin/browser-local/agent-registry.mjs
@@ -1,0 +1,321 @@
+// ABOUTME: Browser-local agent registry for install/login/availability behaviors.
+// ABOUTME: Keeps provider metadata and per-agent setup logic separate from session runtime handling.
+
+import { execFile, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function launchLoginCommand(command) {
+  const loginCommand = `${command} login`;
+
+  if (process.platform === "darwin") {
+    spawn(
+      "osascript",
+      [
+        "-e",
+        `tell application "Terminal" to do script "${loginCommand}"`,
+        "-e",
+        'tell application "Terminal" to activate',
+      ],
+      { detached: true, stdio: "ignore" },
+    ).unref();
+    return;
+  }
+
+  if (process.platform === "win32") {
+    spawn("cmd", ["/c", "start", "cmd", "/c", loginCommand], {
+      detached: true,
+      stdio: "ignore",
+    }).unref();
+    return;
+  }
+
+  spawn("x-terminal-emulator", ["-e", command, "login"], {
+    detached: true,
+    stdio: "ignore",
+  }).unref();
+}
+
+function execText(command, args) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    execFile(command, args, (error, stdout, stderr) => {
+      if (error) {
+        rejectPromise(new Error(stderr || error.message));
+        return;
+      }
+      resolvePromise(stdout.trim());
+    });
+  });
+}
+
+async function isCommandAvailable(command) {
+  const whichCommand = process.platform === "win32" ? "where" : "which";
+  try {
+    await execText(whichCommand, [command]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the path to npm-cli.js relative to the running Node.js binary.
+ * This bypasses shell wrapper shims that break execFile() on macOS/Linux
+ * after Tauri bundling replaces symlinks with shell scripts.
+ *
+ * Layout:
+ *   macOS/Linux: <prefix>/bin/node  → <prefix>/lib/node_modules/npm/bin/npm-cli.js
+ *   Windows:     <prefix>/node.exe  → <prefix>/node_modules/npm/bin/npm-cli.js
+ */
+function resolveNpmCliScript() {
+  const nodeDir = path.dirname(process.execPath);
+
+  if (process.platform === "win32") {
+    // Windows: node.exe sits at the prefix root
+    const candidate = path.join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  } else {
+    // macOS/Linux: node sits in <prefix>/bin/
+    const prefix = path.dirname(nodeDir);
+    const candidate = path.join(prefix, "lib", "node_modules", "npm", "bin", "npm-cli.js");
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+async function ensureGlobalNpmPackage({ emit, command, packageName, label }) {
+  if (await isCommandAvailable(command)) {
+    return command;
+  }
+
+  emit("provider://cli-install-progress", {
+    stage: "installing",
+    message: `Installing ${label} CLI...`,
+  });
+
+  // Invoke node with npm-cli.js directly to avoid shell wrapper shims that
+  // break execFile() after Tauri replaces bin/npm symlinks with shell scripts.
+  const npmCliScript = resolveNpmCliScript();
+  if (npmCliScript) {
+    await new Promise((resolvePromise, rejectPromise) => {
+      execFile(
+        process.execPath,
+        [npmCliScript, "install", "-g", packageName],
+        (error, stdout, stderr) => {
+          if (error) {
+            rejectPromise(new Error(stderr || error.message));
+            return;
+          }
+          resolvePromise(stdout.trim());
+        },
+      );
+    });
+  } else {
+    // Fallback: try npm directly (works in dev where symlinks are intact,
+    // and on Windows where npm.cmd is a valid batch file).
+    const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+    await new Promise((resolvePromise, rejectPromise) => {
+      execFile(
+        npmCommand,
+        ["install", "-g", packageName],
+        (error, stdout, stderr) => {
+          if (error) {
+            rejectPromise(new Error(stderr || error.message));
+            return;
+          }
+          resolvePromise(stdout.trim());
+        },
+      );
+    });
+  }
+
+  emit("provider://cli-install-progress", {
+    stage: "complete",
+    message: `${label} CLI installed successfully`,
+  });
+
+  return command;
+}
+
+async function ensureClaudeCodeViaNativeInstaller(emit) {
+  if (await isCommandAvailable("claude")) {
+    return "claude";
+  }
+
+  emit("provider://cli-install-progress", {
+    stage: "installing",
+    message: "Installing Claude Code CLI via official installer...",
+  });
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    let cmd;
+    let args;
+
+    if (process.platform === "win32") {
+      cmd = "powershell";
+      args = ["-NoProfile", "-Command", "irm https://claude.ai/install.ps1 | iex"];
+    } else {
+      cmd = "bash";
+      args = ["-c", "curl -fsSL https://claude.ai/install.sh | bash"];
+    }
+
+    execFile(cmd, args, { timeout: 120_000 }, (error, stdout, stderr) => {
+      if (error) {
+        rejectPromise(new Error(stderr || error.message));
+        return;
+      }
+      resolvePromise(stdout.trim());
+    });
+  });
+
+  emit("provider://cli-install-progress", {
+    stage: "complete",
+    message: "Claude Code CLI installed successfully",
+  });
+
+  // Re-resolve the binary path after install. The installer adds the binary
+  // to a well-known location that the current process PATH may not include.
+  return resolveInstalledClaudeBinary();
+}
+
+/**
+ * Resolve the installed Claude Code binary path.
+ * GUI apps don't inherit shell PATH updates made by installers, so check
+ * well-known install locations before falling back to bare command name.
+ */
+function resolveInstalledClaudeBinary() {
+  if (process.platform === "win32") {
+    const home = os.homedir();
+    const appData = process.env.APPDATA ?? "";
+    const candidates = [
+      path.join(home, ".claude", "bin", "claude.exe"),
+      ...(appData ? [path.join(appData, "Claude", "claude.exe")] : []),
+      ...(appData ? [path.join(appData, "npm", "claude.cmd")] : []),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  } else {
+    const home = os.homedir();
+    const candidates = [
+      path.join(home, ".claude", "bin", "claude"),
+      path.join(home, ".local", "bin", "claude"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return "claude";
+}
+
+export function createBrowserLocalAgentRegistry({ emit }) {
+  const definitions = {
+    codex: {
+      type: "codex",
+      name: "Codex",
+      description: "OpenAI Codex via direct App Server integration",
+      command: "codex",
+      async getAvailability() {
+        const installed = await isCommandAvailable("codex");
+        return {
+          type: "codex",
+          name: "Codex",
+          description: "OpenAI Codex via direct App Server integration",
+          command: "codex",
+          available: true,
+          ...(installed
+            ? {}
+            : {
+                unavailableReason:
+                  "Codex CLI is not installed yet. Seren can install it automatically on first launch.",
+              }),
+        };
+      },
+      async canSpawn() {
+        return true;
+      },
+      async ensureCli() {
+        return ensureGlobalNpmPackage({
+          emit,
+          command: "codex",
+          packageName: "@openai/codex",
+          label: "Codex",
+        });
+      },
+      launchLogin() {
+        launchLoginCommand("codex");
+      },
+    },
+    "claude-code": {
+      type: "claude-code",
+      name: "Claude Code",
+      description: "Anthropic Claude Code via direct provider runtime",
+      command: "claude",
+      async getAvailability() {
+        const installed = await isCommandAvailable("claude");
+        return {
+          type: "claude-code",
+          name: "Claude Code",
+          description: "Anthropic Claude Code via direct provider runtime",
+          command: "claude",
+          available: true,
+          ...(installed
+            ? {}
+            : {
+                unavailableReason:
+                  "Claude Code CLI is not installed yet. Seren can install it automatically on first launch.",
+              }),
+        };
+      },
+      async canSpawn() {
+        return true;
+      },
+      async ensureCli() {
+        return ensureClaudeCodeViaNativeInstaller(emit);
+      },
+      launchLogin() {
+        launchLoginCommand("claude");
+      },
+    },
+  };
+
+  function getDefinition(agentType) {
+    const definition = definitions[agentType];
+    if (!definition) {
+      throw new Error(`Unknown agent type: ${agentType}`);
+    }
+    return definition;
+  }
+
+  return {
+    async getAvailableAgents() {
+      return Promise.all(
+        Object.values(definitions).map((definition) =>
+          definition.getAvailability(),
+        ),
+      );
+    },
+
+    async checkAgentAvailable(agentType) {
+      return getDefinition(agentType).canSpawn();
+    },
+
+    async ensureAgentCli(agentType) {
+      return getDefinition(agentType).ensureCli();
+    },
+
+    launchLogin(agentType) {
+      getDefinition(agentType).launchLogin();
+    },
+  };
+}

--- a/runtime/bin/browser-local/claude-runtime.mjs
+++ b/runtime/bin/browser-local/claude-runtime.mjs
@@ -1,0 +1,1793 @@
+// ABOUTME: Browser-local Claude Code runtime backed by the local claude CLI.
+// ABOUTME: Manages long-lived stream-json sessions, permissions, and session listing without ACP.
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync, readdirSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+import { buildProviderMcpConfig } from "./mcp-config.mjs";
+
+/**
+ * Resolve the full path to the `claude` binary.
+ * GUI apps don't inherit shell profile PATH additions, so `which claude`
+ * and bare `spawn("claude")` may fail even when Claude Code is installed.
+ * Check well-known install locations before falling back to bare command name.
+ */
+function resolveClaudeBinary() {
+  if (process.platform === "win32") {
+    const home = os.homedir();
+    const appData = process.env.APPDATA ?? "";
+    const candidates = [
+      // Native installer (install.ps1) places binary here
+      path.join(home, ".claude", "bin", "claude.exe"),
+      // Legacy/alternate location
+      ...(appData ? [path.join(appData, "Claude", "claude.exe")] : []),
+      // npm global install creates a .cmd wrapper here
+      ...(appData ? [path.join(appData, "npm", "claude.cmd")] : []),
+    ];
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    // Try PATH lookup via `where`
+    try {
+      const resolved = execFileSync("where", ["claude"], {
+        encoding: "utf8",
+        timeout: 5_000,
+      }).trim().split(/\r?\n/)[0];
+      if (resolved) {
+        return resolved;
+      }
+    } catch {
+      // where failed — fall through to bare command name
+    }
+
+    return "claude";
+  }
+
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, ".claude", "bin", "claude"),
+    path.join(home, ".local", "bin", "claude"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Try PATH lookup (works when Rust side has extended PATH correctly)
+  try {
+    const resolved = execFileSync("which", ["claude"], {
+      encoding: "utf8",
+      timeout: 5_000,
+    }).trim();
+    if (resolved) {
+      return resolved;
+    }
+  } catch {
+    // which failed — fall through to bare command name
+  }
+
+  return "claude";
+}
+
+/**
+ * Build a PATH string that includes well-known CLI install locations.
+ * GUI apps don't inherit the user's shell profile, so tools installed via
+ * native installers or npm global aren't on PATH. Without this, spawned
+ * processes fail with "command not found" / "not recognized".
+ */
+function buildExtendedPath() {
+  const sep = process.platform === "win32" ? ";" : ":";
+  const base = process.env.PATH ?? "";
+
+  if (process.platform === "win32") {
+    const home = os.homedir();
+    const appData = process.env.APPDATA ?? "";
+    const winExtra = [
+      // Claude Code native installer (install.ps1)
+      path.join(home, ".claude", "bin"),
+      // npm global bin directory
+      ...(appData ? [path.join(appData, "npm")] : []),
+    ];
+    const winAdditions = winExtra.filter((p) => p && !base.includes(p));
+    return winAdditions.length > 0
+      ? `${winAdditions.join(sep)}${sep}${base}`
+      : base;
+  }
+
+  const home = os.homedir();
+  const extra = [
+    // nvm (most common)
+    path.join(home, ".nvm", "versions", "node"),
+    // fnm
+    path.join(home, ".local", "share", "fnm", "aliases", "default", "bin"),
+    path.join(home, "Library", "Application Support", "fnm", "aliases", "default", "bin"),
+    // Volta
+    path.join(home, ".volta", "bin"),
+    // Homebrew (Apple Silicon + Intel)
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    // Common Linux paths
+    "/usr/bin",
+  ];
+
+  // For nvm, find the active or default version directory
+  const nvmDir = extra[0];
+  if (existsSync(nvmDir)) {
+    try {
+      const versions = readdirSync(nvmDir).sort().reverse();
+      for (const ver of versions) {
+        const binDir = path.join(nvmDir, ver, "bin");
+        if (existsSync(binDir)) {
+          extra[0] = binDir;
+          break;
+        }
+      }
+    } catch {
+      // Can't read nvm versions — remove placeholder
+      extra[0] = "";
+    }
+  } else {
+    extra[0] = "";
+  }
+
+  const additions = extra.filter((p) => p && !base.includes(p));
+  return additions.length > 0 ? `${additions.join(sep)}${sep}${base}` : base;
+}
+
+function isAuthError(message) {
+  const lower = String(message).toLowerCase();
+  return (
+    lower.includes("invalid api key") ||
+    lower.includes("authentication required") ||
+    lower.includes("auth required") ||
+    lower.includes("failed to authenticate") ||
+    lower.includes("login required") ||
+    lower.includes("not logged in") ||
+    lower.includes("please login again") ||
+    lower.includes("please sign in") ||
+    lower.includes("session expired") ||
+    lower.includes("does not have access") ||
+    lower.includes("re-authenticate")
+  );
+}
+
+function killChildTree(child) {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+      return;
+    } catch {
+      // Fall through to direct kill.
+    }
+  }
+
+  try {
+    child.kill();
+  } catch {
+    // Ignore double-kill races during cleanup.
+  }
+}
+
+function encodeProjectDirName(cwd) {
+  const resolved = path.resolve(cwd);
+  const unixPath = resolved.replaceAll("\\", "/");
+  const sanitized = unixPath.replace(/^\/+/, "").replaceAll(":", "");
+  return `-${sanitized.replaceAll("/", "-")}`;
+}
+
+function claudeProjectsRoot() {
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(targetPath) {
+  const bytes = await fs.readFile(targetPath, "utf8");
+  return JSON.parse(bytes);
+}
+
+async function findSessionsIndexPath(cwd) {
+  const root = claudeProjectsRoot();
+  const direct = path.join(root, encodeProjectDirName(cwd), "sessions-index.json");
+  if (await pathExists(direct)) {
+    return direct;
+  }
+
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const resolvedCwd = path.resolve(cwd);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const indexPath = path.join(root, entry.name, "sessions-index.json");
+    if (!(await pathExists(indexPath))) {
+      continue;
+    }
+
+    try {
+      const index = await readJson(indexPath);
+      if (
+        index?.originalPath === resolvedCwd ||
+        index?.originalPath === cwd
+      ) {
+        return indexPath;
+      }
+    } catch {
+      // Ignore malformed indexes.
+    }
+  }
+
+  return null;
+}
+
+async function readSessionsIndex(cwd) {
+  const indexPath = await findSessionsIndexPath(cwd);
+  if (!indexPath) {
+    return null;
+  }
+
+  try {
+    return await readJson(indexPath);
+  } catch {
+    return null;
+  }
+}
+
+async function findSessionJsonlPath(cwd, sessionId) {
+  const index = await readSessionsIndex(cwd);
+  const entry = index?.entries?.find?.((candidate) => candidate.sessionId === sessionId);
+  if (entry?.fullPath) {
+    return entry.fullPath;
+  }
+
+  const inferred = path.join(
+    claudeProjectsRoot(),
+    encodeProjectDirName(cwd),
+    `${sessionId}.jsonl`,
+  );
+  if (await pathExists(inferred)) {
+    return inferred;
+  }
+
+  let entries;
+  try {
+    entries = await fs.readdir(claudeProjectsRoot(), { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  for (const directory of entries) {
+    if (!directory.isDirectory()) {
+      continue;
+    }
+    const candidate = path.join(
+      claudeProjectsRoot(),
+      directory.name,
+      `${sessionId}.jsonl`,
+    );
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function buildModeState(currentModeId) {
+  return {
+    currentModeId,
+    availableModes: [
+      {
+        modeId: "default",
+        name: "Default",
+        description: "Standard behavior",
+      },
+      {
+        modeId: "acceptEdits",
+        name: "Accept Edits",
+        description: "Auto-accept file edit operations",
+      },
+      {
+        modeId: "plan",
+        name: "Plan Mode",
+        description: "Planning mode; no actual tool execution",
+      },
+      {
+        modeId: "bypassPermissions",
+        name: "Bypass Permissions",
+        description: "Auto-approve all operations",
+      },
+    ],
+  };
+}
+
+function buildAvailableModels(session) {
+  return session.availableModelRecords.map((record) => ({
+    modelId: record.modelId,
+    name: record.name,
+    description: record.description,
+  }));
+}
+
+function buildSessionStatus(session, status = session.status) {
+  return {
+    sessionId: session.id,
+    status,
+    agentSessionId: session.agentSessionId,
+    agentInfo: {
+      name: "Claude Code",
+      version: session.claudeVersion ?? "unknown",
+    },
+    ...(session.availableModelRecords.length > 0
+      ? {
+          models: {
+            currentModelId:
+              session.currentModelId ??
+              session.availableModelRecords[0]?.modelId ??
+              "default",
+            availableModels: buildAvailableModels(session),
+          },
+        }
+      : {}),
+    modes: buildModeState(session.currentModeId),
+  };
+}
+
+function normalizeModelRecords(result) {
+  const models = Array.isArray(result?.models) ? result.models : [];
+  return models
+    .map((record) => ({
+      modelId: record?.value ?? null,
+      name: record?.displayName ?? record?.value ?? "Unknown model",
+      description: record?.description ?? undefined,
+      supportsEffort: record?.supportsEffort === true,
+      supportedEffortLevels: Array.isArray(record?.supportedEffortLevels)
+        ? record.supportedEffortLevels.filter(
+            (effort) => typeof effort === "string",
+          )
+        : [],
+      isDefault: record?.value === "default",
+    }))
+    .filter((record) => typeof record.modelId === "string");
+}
+
+function inferCurrentModelId(currentModel, records) {
+  if (!currentModel || records.length === 0) {
+    return records[0]?.modelId ?? null;
+  }
+
+  const exact = records.find((record) => record.modelId === currentModel);
+  if (exact) {
+    return exact.modelId;
+  }
+
+  const lower = String(currentModel).toLowerCase();
+  if (lower.includes("opus")) {
+    return (
+      records.find((record) => record.modelId === "default")?.modelId ??
+      records.find((record) => record.modelId.startsWith("opus"))?.modelId ??
+      records[0]?.modelId ??
+      null
+    );
+  }
+
+  if (lower.includes("sonnet")) {
+    return (
+      records.find((record) => record.modelId.startsWith("sonnet"))?.modelId ??
+      records[0]?.modelId ??
+      null
+    );
+  }
+
+  if (lower.includes("haiku")) {
+    return (
+      records.find((record) => record.modelId.startsWith("haiku"))?.modelId ??
+      records[0]?.modelId ??
+      null
+    );
+  }
+
+  return records[0]?.modelId ?? null;
+}
+
+function combinePrompt(prompt, context) {
+  const contextText = Array.isArray(context)
+    ? context
+        .map((entry) => entry?.text)
+        .filter((value) => typeof value === "string" && value.length > 0)
+        .join("\n\n")
+    : "";
+  return [contextText, prompt].filter(Boolean).join("\n\n");
+}
+
+function toolKindForName(toolName) {
+  const lower = String(toolName ?? "").toLowerCase();
+  if (lower.includes("bash") || lower.includes("shell") || lower.includes("exec")) {
+    return "commandExecution";
+  }
+  if (lower.includes("read")) {
+    return "fileRead";
+  }
+  if (
+    lower.includes("edit") ||
+    lower.includes("write") ||
+    lower.includes("replace")
+  ) {
+    return "fileChange";
+  }
+  if (
+    lower.includes("search") ||
+    lower.includes("grep") ||
+    lower.includes("glob")
+  ) {
+    return "search";
+  }
+  if (lower.includes("fetch") || lower.includes("web")) {
+    return "webFetch";
+  }
+  return toolName ?? "tool";
+}
+
+function isEditLikeTool(toolName) {
+  const lower = String(toolName ?? "").toLowerCase();
+  return (
+    lower.includes("edit") ||
+    lower.includes("write") ||
+    lower.includes("replace") ||
+    lower.includes("notebookedit")
+  );
+}
+
+function resolveToolTitle(toolName, input) {
+  if (toolName === "Bash" && typeof input?.description === "string") {
+    return input.description;
+  }
+  if (toolName === "Bash" && typeof input?.command === "string") {
+    return input.command;
+  }
+  if (typeof input?.file_path === "string") {
+    return `${toolName}: ${input.file_path}`;
+  }
+  if (typeof input?.path === "string") {
+    return `${toolName}: ${input.path}`;
+  }
+  return toolName ?? "Tool call";
+}
+
+function buildPermissionToolCall(toolName, input, toolUseId) {
+  return {
+    id: toolUseId,
+    name: toolName,
+    title: resolveToolTitle(toolName, input),
+    input,
+  };
+}
+
+function stringifyToolResultContent(content) {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    const textParts = content
+      .map((block) =>
+        typeof block?.text === "string"
+          ? block.text
+          : typeof block === "string"
+            ? block
+            : JSON.stringify(block),
+      )
+      .filter((value) => typeof value === "string" && value.length > 0);
+    if (textParts.length > 0) {
+      return textParts.join("\n");
+    }
+    return JSON.stringify(content);
+  }
+
+  if (content && typeof content === "object") {
+    return JSON.stringify(content);
+  }
+
+  return undefined;
+}
+
+function emitToolCall(emit, session, toolName, input, toolUseId, status = "in_progress") {
+  if (typeof toolUseId === "string" && toolUseId.length > 0) {
+    session.toolInputs.set(toolUseId, input ?? {});
+  }
+  const title = resolveToolTitle(toolName, input);
+  emit("provider://tool-call", {
+    sessionId: session.id,
+    toolCallId: toolUseId,
+    title,
+    kind: toolKindForName(toolName),
+    status,
+    parameters: input,
+  });
+}
+
+function emitToolResult(emit, session, toolUseId, content, isError = false) {
+  emit("provider://tool-result", {
+    sessionId: session.id,
+    toolCallId: toolUseId,
+    status: isError ? "failed" : "completed",
+    result: isError ? undefined : stringifyToolResultContent(content),
+    error: isError ? stringifyToolResultContent(content) ?? "Tool failed." : undefined,
+  });
+}
+
+function resolveCurrentPrompt(session) {
+  if (!session.currentPrompt) {
+    return;
+  }
+
+  const pending = session.currentPrompt;
+  session.currentPrompt = null;
+  pending.resolve();
+}
+
+function rejectCurrentPrompt(session, error) {
+  if (!session.currentPrompt) {
+    return;
+  }
+
+  const pending = session.currentPrompt;
+  session.currentPrompt = null;
+  pending.reject(error);
+}
+
+function rejectPendingControlRequests(session, error) {
+  for (const [key, pending] of session.pendingControlRequests) {
+    clearTimeout(pending.timeout);
+    pending.reject(error);
+    session.pendingControlRequests.delete(key);
+  }
+}
+
+function writeMessage(session, payload) {
+  session.process.stdin.write(`${JSON.stringify(payload)}\n`);
+}
+
+function sendControlRequest(session, request, timeoutMs = 30_000) {
+  const requestId = `req_${session.nextControlRequestId}_${randomUUID().replaceAll("-", "")}`;
+  session.nextControlRequestId += 1;
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timeout = setTimeout(() => {
+      session.pendingControlRequests.delete(requestId);
+      rejectPromise(
+        new Error(`Timed out waiting for Claude control request ${request.subtype}.`),
+      );
+    }, timeoutMs);
+
+    session.pendingControlRequests.set(requestId, {
+      timeout,
+      resolve: resolvePromise,
+      reject: rejectPromise,
+      subtype: request.subtype,
+    });
+
+    writeMessage(session, {
+      type: "control_request",
+      request_id: requestId,
+      request,
+    });
+  });
+}
+
+function buildClaudeArgs({
+  sessionId,
+  resumeSessionId,
+  forkSession,
+  preferredModel,
+  mcpConfigJson,
+}) {
+  const args = [
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--input-format",
+    "stream-json",
+    "--include-partial-messages",
+    "--replay-user-messages",
+    // Claude only emits approval requests over stream-json when explicitly
+    // bridged over stdio; otherwise tools fail with `permission_denials`.
+    "--permission-prompt-tool",
+    "stdio",
+    // Allow switching into bypassPermissions later from the UI footer.
+    "--allow-dangerously-skip-permissions",
+  ];
+
+  if (mcpConfigJson) {
+    args.push("--mcp-config", mcpConfigJson, "--strict-mcp-config");
+  }
+
+  if (resumeSessionId) {
+    args.push("--resume", resumeSessionId);
+  }
+
+  if (!resumeSessionId || forkSession) {
+    args.push("--session-id", sessionId);
+  }
+
+  if (forkSession) {
+    args.push("--fork-session");
+  }
+
+  if (preferredModel) {
+    args.push("--model", preferredModel);
+  }
+
+  return args;
+}
+
+function buildPromptMeta(result) {
+  const usage = result?.usage ?? {};
+  // result.usage reports CUMULATIVE tokens across all iterations (tool
+  // call round-trips) in this prompt. For autocompact we need the
+  // approximate context window fill — the input for a single API call.
+  // Divide cumulative total by num_turns to approximate per-turn usage.
+  const rawInput =
+    typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+  const cacheCreation =
+    typeof usage.cache_creation_input_tokens === "number"
+      ? usage.cache_creation_input_tokens
+      : 0;
+  const cacheRead =
+    typeof usage.cache_read_input_tokens === "number"
+      ? usage.cache_read_input_tokens
+      : 0;
+  const cumulativeInput = rawInput + cacheCreation + cacheRead;
+  const numTurns =
+    typeof result?.num_turns === "number" && result.num_turns > 0
+      ? result.num_turns
+      : 1;
+  const inputTokens =
+    cumulativeInput > 0 ? Math.round(cumulativeInput / numTurns) : undefined;
+  const outputTokens =
+    typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
+
+  // Extract context window size from modelUsage if available.
+  const modelUsage = result?.modelUsage ?? {};
+  const firstModel = Object.values(modelUsage)[0];
+  const contextWindow =
+    typeof firstModel?.contextWindow === "number"
+      ? firstModel.contextWindow
+      : undefined;
+
+  return {
+    meta: {
+      ...(inputTokens != null || outputTokens != null
+        ? {
+            usage: {
+              ...(inputTokens != null ? { input_tokens: inputTokens } : {}),
+              ...(outputTokens != null ? { output_tokens: outputTokens } : {}),
+            },
+          }
+        : {}),
+      ...(contextWindow != null ? { contextWindow } : {}),
+      ...(typeof result?.num_turns === "number" ? { numTurns: result.num_turns } : {}),
+    },
+  };
+}
+
+function replayMetaFromHistoryEntry(entry) {
+  const messageId =
+    typeof entry?.uuid === "string" && entry.uuid.length > 0
+      ? entry.uuid
+      : undefined;
+  const rawTimestamp = entry?.timestamp;
+  const timestamp =
+    typeof rawTimestamp === "number"
+      ? rawTimestamp
+      : typeof rawTimestamp === "string" && rawTimestamp.length > 0
+        ? Date.parse(rawTimestamp)
+        : undefined;
+
+  return {
+    messageId,
+    timestamp:
+      typeof timestamp === "number" && Number.isFinite(timestamp)
+        ? timestamp
+        : undefined,
+  };
+}
+
+function replayClaudeHistoryEntry(emit, session, entry) {
+  const type = entry?.type;
+  if (type !== "user" && type !== "assistant") {
+    return;
+  }
+
+  const blocks = Array.isArray(entry?.message?.content) ? entry.message.content : [];
+  const { messageId, timestamp } = replayMetaFromHistoryEntry(entry);
+
+  for (const block of blocks) {
+    switch (block?.type) {
+      case "text":
+        if (typeof block.text !== "string" || block.text.length === 0) {
+          break;
+        }
+        if (type === "user") {
+          emit("provider://user-message", {
+            sessionId: session.id,
+            text: block.text,
+            messageId,
+            timestamp,
+            replay: true,
+          });
+        } else {
+          emit("provider://message-chunk", {
+            sessionId: session.id,
+            text: block.text,
+            messageId,
+            timestamp,
+            replay: true,
+          });
+        }
+        break;
+
+      case "thinking":
+        if (type !== "assistant") {
+          break;
+        }
+        if (typeof block.thinking !== "string" || block.thinking.length === 0) {
+          break;
+        }
+        emit("provider://message-chunk", {
+          sessionId: session.id,
+          text: block.thinking,
+          isThought: true,
+          messageId,
+          timestamp,
+          replay: true,
+        });
+        break;
+
+      case "tool_use":
+        if (type !== "assistant") {
+          break;
+        }
+        if (typeof block.id !== "string" || typeof block.name !== "string") {
+          break;
+        }
+        emitToolCall(
+          emit,
+          session,
+          block.name,
+          block.input ?? {},
+          block.id,
+          "completed",
+        );
+        break;
+
+      case "tool_result":
+        if (type !== "user" || typeof block.tool_use_id !== "string") {
+          break;
+        }
+        emitToolResult(
+          emit,
+          session,
+          block.tool_use_id,
+          block.content ?? null,
+          block.is_error === true,
+        );
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+async function replayClaudeHistoryBestEffort(emit, session, cwd, sessionId) {
+  const historyPath = await findSessionJsonlPath(cwd, sessionId);
+  if (!historyPath) {
+    return;
+  }
+
+  let bytes;
+  try {
+    bytes = await fs.readFile(historyPath, "utf8");
+  } catch {
+    return;
+  }
+
+  for (const line of bytes.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    let entry;
+    try {
+      entry = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+
+    replayClaudeHistoryEntry(emit, session, entry);
+  }
+
+  emit("provider://prompt-complete", {
+    sessionId: session.id,
+    stopReason: "HistoryReplay",
+    historyReplay: true,
+  });
+}
+
+function handleControlResponse(session, payload) {
+  const requestId = payload?.response?.request_id;
+  if (typeof requestId !== "string") {
+    return;
+  }
+
+  const pending = session.pendingControlRequests.get(requestId);
+  if (!pending) {
+    return;
+  }
+
+  clearTimeout(pending.timeout);
+  session.pendingControlRequests.delete(requestId);
+
+  if (payload?.response?.subtype && payload.response.subtype !== "success") {
+    pending.reject(
+      new Error(
+        `${pending.subtype} failed: ${payload.response.message ?? payload.response.subtype}`,
+      ),
+    );
+    return;
+  }
+
+  pending.resolve(payload?.response?.response ?? null);
+}
+
+function autoPermissionDecision(session, toolName) {
+  if (session.allowedTools.has(toolName)) {
+    return "allow_once";
+  }
+
+  switch (session.currentModeId) {
+    case "bypassPermissions":
+      return "allow_once";
+    case "acceptEdits":
+      return isEditLikeTool(toolName) ? "allow_once" : "ask";
+    case "plan":
+      return "deny";
+    default:
+      return "ask";
+  }
+}
+
+function buildPermissionResponse(optionId, toolInput) {
+  switch (optionId) {
+    case "allow_once":
+      return {
+        behavior: "allow",
+        updatedInput: toolInput,
+      };
+    case "allow_session":
+      return {
+        behavior: "allow",
+        updatedInput: toolInput,
+      };
+    case "cancel":
+      return {
+        behavior: "deny",
+        message: "Turn cancelled",
+        interrupt: true,
+      };
+    case "deny":
+    default:
+      return {
+        behavior: "deny",
+        message: "Tool use denied",
+        interrupt: false,
+      };
+  }
+}
+
+function respondToControlRequest(session, payload, response) {
+  writeMessage(session, {
+    type: "control_response",
+    response: {
+      subtype: "success",
+      request_id: payload.request_id,
+      response,
+    },
+  });
+}
+
+function handlePermissionRequest(emit, session, payload) {
+  const subtype = payload?.request?.subtype;
+  if (subtype !== "can_use_tool") {
+    respondToControlRequest(session, payload, {
+      behavior: "deny",
+      message: `Unsupported Claude control request: ${subtype ?? "unknown"}`,
+      interrupt: true,
+    });
+    return;
+  }
+
+  const toolName =
+    payload.request.tool_name ?? payload.request.toolName ?? "Tool";
+  const toolInput =
+    payload.request.input ??
+    payload.request.tool_input ??
+    payload.request.toolInput ??
+    session.toolInputs.get(
+      payload.request.tool_use_id ?? payload.request.toolUseId ?? "",
+    ) ??
+    {};
+  const toolUseId =
+    payload.request.tool_use_id ?? payload.request.toolUseId ?? randomUUID();
+
+  emitToolCall(emit, session, toolName, toolInput, toolUseId, "pending");
+
+  const autoDecision = autoPermissionDecision(session, toolName);
+  if (autoDecision === "allow_once") {
+    respondToControlRequest(
+      session,
+      payload,
+      buildPermissionResponse("allow_once", toolInput),
+    );
+    return;
+  }
+
+  if (autoDecision === "deny") {
+    emitToolResult(
+      emit,
+      session,
+      toolUseId,
+      "Plan mode does not allow tool execution.",
+      true,
+    );
+    respondToControlRequest(session, payload, buildPermissionResponse("deny", toolInput));
+    return;
+  }
+
+  const requestId = randomUUID();
+  session.pendingPermissions.set(requestId, {
+    controlRequestId: payload.request_id,
+    toolName,
+    toolInput,
+    toolUseId,
+  });
+
+  emit("provider://permission-request", {
+    sessionId: session.id,
+    requestId,
+    toolCall: buildPermissionToolCall(toolName, toolInput, toolUseId),
+    options: [
+      {
+        optionId: "allow_once",
+        label: "Allow once",
+        description: "Allow this action one time.",
+      },
+      {
+        optionId: "allow_session",
+        label: "Allow session",
+        description: "Allow this tool for the rest of this session.",
+      },
+      {
+        optionId: "deny",
+        label: "Reject",
+        description: "Reject this action but keep the turn running.",
+      },
+      {
+        optionId: "cancel",
+        label: "Cancel turn",
+        description: "Reject this action and interrupt the turn.",
+      },
+    ],
+  });
+}
+
+function handleSystemMessage(emit, session, payload) {
+  switch (payload.subtype) {
+    case "init": {
+      if (typeof payload.session_id === "string") {
+        session.agentSessionId = payload.session_id;
+      }
+      if (typeof payload.claude_code_version === "string") {
+        session.claudeVersion = payload.claude_code_version;
+      }
+      if (typeof payload.permissionMode === "string") {
+        session.currentModeId = payload.permissionMode;
+      }
+      session.currentModelId =
+        session.currentModelId ??
+        inferCurrentModelId(payload.model, session.availableModelRecords);
+      emit("provider://session-status", buildSessionStatus(session));
+      return;
+    }
+
+    case "status":
+      if (typeof payload.permissionMode === "string") {
+        session.currentModeId = payload.permissionMode;
+      }
+      emit("provider://session-status", buildSessionStatus(session));
+      return;
+
+    case "hook_response":
+      if (payload.outcome === "error" && payload.stderr) {
+        console.warn(`[browser-local][claude] Hook error: ${payload.stderr}`);
+      }
+      return;
+
+    default:
+      return;
+  }
+}
+
+function handleAssistantMessage(emit, session, payload) {
+  const message = payload?.message ?? {};
+  const blocks = Array.isArray(message.content) ? message.content : [];
+  const sawStreamedAssistant =
+    session.currentPrompt != null && session.currentPromptHasChunks === true;
+
+  if (typeof payload.session_id === "string") {
+    session.agentSessionId = payload.session_id;
+  }
+  if (typeof session.currentModelId !== "string") {
+    session.currentModelId = inferCurrentModelId(
+      message.model,
+      session.availableModelRecords,
+    );
+  }
+
+  for (const block of blocks) {
+    switch (block?.type) {
+      case "text":
+        if (!sawStreamedAssistant && typeof block.text === "string" && block.text.length > 0) {
+          session.currentPromptHasChunks = true;
+          emit("provider://message-chunk", {
+            sessionId: session.id,
+            text: block.text,
+          });
+        }
+        break;
+
+      case "thinking":
+        if (
+          !sawStreamedAssistant &&
+          typeof block.thinking === "string" &&
+          block.thinking.length > 0
+        ) {
+          session.currentPromptHasChunks = true;
+          emit("provider://message-chunk", {
+            sessionId: session.id,
+            text: block.thinking,
+            isThought: true,
+          });
+        }
+        break;
+
+      case "tool_use":
+        if (typeof block.id === "string" && typeof block.name === "string") {
+          emitToolCall(emit, session, block.name, block.input ?? {}, block.id);
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+function handleUserMessage(emit, session, payload) {
+  const message = payload?.message ?? {};
+  const blocks = Array.isArray(message.content) ? message.content : [];
+
+  for (const block of blocks) {
+    if (block?.type !== "tool_result" || typeof block.tool_use_id !== "string") {
+      continue;
+    }
+    emitToolResult(
+      emit,
+      session,
+      block.tool_use_id,
+      block.content ?? null,
+      block.is_error === true,
+    );
+  }
+}
+
+function handleStreamEvent(emit, session, payload) {
+  const event = payload?.event ?? {};
+  switch (event.type) {
+    case "message_start":
+      session.currentPromptHasChunks = false;
+      return;
+
+    case "content_block_delta": {
+      const delta = event.delta ?? {};
+      if (delta.type === "text_delta" && typeof delta.text === "string") {
+        session.currentPromptHasChunks = true;
+        emit("provider://message-chunk", {
+          sessionId: session.id,
+          text: delta.text,
+        });
+      } else if (
+        delta.type === "thinking_delta" &&
+        typeof delta.thinking === "string"
+      ) {
+        session.currentPromptHasChunks = true;
+        emit("provider://message-chunk", {
+          sessionId: session.id,
+          text: delta.thinking,
+          isThought: true,
+        });
+      }
+      return;
+    }
+
+    default:
+      return;
+  }
+}
+
+function handleResult(emit, session, payload) {
+  session.status = "ready";
+
+  emit("provider://prompt-complete", {
+    sessionId: session.id,
+    stopReason: payload?.stop_reason ?? (payload?.is_error ? "error" : "end_turn"),
+    ...buildPromptMeta(payload),
+  });
+  emit("provider://session-status", buildSessionStatus(session, "ready"));
+
+  if (payload?.is_error) {
+    const message =
+      payload?.result ??
+      payload?.error ??
+      "Claude Code request failed.";
+    emit("provider://error", {
+      sessionId: session.id,
+      error: isAuthError(message)
+        ? "Agent authentication required. Run the login flow and try again."
+        : message,
+    });
+    rejectCurrentPrompt(session, new Error(message));
+    return;
+  }
+
+  resolveCurrentPrompt(session);
+}
+
+function handleLine(emit, session, line) {
+  let payload;
+  try {
+    payload = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  switch (payload?.type) {
+    case "control_response":
+      handleControlResponse(session, payload);
+      return;
+    case "control_request":
+      handlePermissionRequest(emit, session, payload);
+      return;
+    case "system":
+      handleSystemMessage(emit, session, payload);
+      return;
+    case "assistant":
+      handleAssistantMessage(emit, session, payload);
+      return;
+    case "user":
+      handleUserMessage(emit, session, payload);
+      return;
+    case "stream_event":
+      handleStreamEvent(emit, session, payload);
+      return;
+    case "result":
+      handleResult(emit, session, payload);
+      return;
+    default:
+      return;
+  }
+}
+
+function attachProcessListeners(emit, sessions, session, exitPromises) {
+  session.output.on("line", (line) => handleLine(emit, session, line));
+
+  session.process.stderr.on("data", (chunk) => {
+    const message = String(chunk).trim();
+    if (message.length > 0) {
+      console.log(`[browser-local][claude] ${message}`);
+    }
+  });
+
+  // Register an exit promise so spawnSession can wait for full cleanup
+  // before reusing the same session ID.
+  let resolveExit;
+  exitPromises.set(session.id, new Promise((r) => { resolveExit = r; }));
+
+  session.process.on("exit", () => {
+    const wasTracked = sessions.delete(session.id);
+
+    // Resolve the exit promise AFTER cleanup so waiters know it's safe
+    // to reuse this session ID.
+    const finish = () => {
+      exitPromises.delete(session.id);
+      resolveExit();
+    };
+
+    if (!wasTracked) {
+      finish();
+      return;
+    }
+
+    rejectPendingControlRequests(
+      session,
+      new Error("Claude Code stopped before request completed."),
+    );
+
+    if (session.currentPrompt) {
+      rejectCurrentPrompt(
+        session,
+        new Error("Claude Code stopped while prompt was active."),
+      );
+      emit("provider://error", {
+        sessionId: session.id,
+        error: "Claude Code stopped while prompt was active.",
+      });
+    }
+
+    session.status = "terminated";
+    emit("provider://session-status", {
+      sessionId: session.id,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+
+    finish();
+  });
+}
+
+export function createClaudeRuntime({ emit }) {
+  const sessions = new Map();
+  // Tracks pending exit cleanup per session ID. When a process exits,
+  // the promise resolves. Before spawning with a reused ID, we await
+  // this to prevent the old exit handler from deleting the new session.
+  const exitPromises = new Map();
+  const silentEmit = () => {};
+
+  function createSessionRecord({
+    sessionId,
+    cwd,
+    processHandle,
+    timeoutSecs,
+    agentSessionId,
+    currentModelId = null,
+    currentModeId = "default",
+    mcpConfigJson = null,
+    spawnEnv = {},
+  }) {
+    return {
+      id: sessionId,
+      agentType: "claude-code",
+      cwd,
+      status: "initializing",
+      createdAt: new Date().toISOString(),
+      process: processHandle,
+      output: readline.createInterface({ input: processHandle.stdout }),
+      pendingControlRequests: new Map(),
+      nextControlRequestId: 1,
+      pendingPermissions: new Map(),
+      currentPrompt: null,
+      currentPromptHasChunks: false,
+      allowedTools: new Set(),
+      toolInputs: new Map(),
+      agentSessionId,
+      timeoutSecs: timeoutSecs ?? undefined,
+      claudeVersion: null,
+      availableModelRecords: [],
+      currentModelId,
+      currentModeId,
+      mcpConfigJson,
+      spawnEnv,
+    };
+  }
+
+  function claudeModeFromApprovalPolicy(approvalPolicy) {
+    switch (approvalPolicy) {
+      case "on-request":
+      case "untrusted":
+      case "on-failure":
+        return "acceptEdits";
+      case "never":
+        return "bypassPermissions";
+      default:
+        return "acceptEdits";
+    }
+  }
+
+  async function spawnSession(params) {
+    const {
+      cwd,
+      localSessionId,
+      resumeAgentSessionId,
+      apiKey,
+      mcpServers,
+      approvalPolicy,
+      timeoutSecs,
+    } = params;
+
+    const sessionId = localSessionId ?? randomUUID();
+
+    // Wait for any previous process using this session ID to fully exit.
+    // Without this, the old exit handler fires after the new session is
+    // registered and deletes it from the sessions Map.
+    const pendingExit = exitPromises.get(sessionId);
+    if (pendingExit) {
+      await pendingExit;
+    }
+
+    const remoteSessionId = resumeAgentSessionId ?? randomUUID();
+    const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+    const claudeBin = resolveClaudeBinary();
+    const extendedPath = buildExtendedPath();
+    const processHandle = spawn(
+      claudeBin,
+      buildClaudeArgs({
+        sessionId: remoteSessionId,
+        resumeSessionId: resumeAgentSessionId ?? null,
+        forkSession: false,
+        preferredModel: null,
+        mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+      }),
+      {
+        cwd,
+        env: {
+          ...process.env,
+          ...mcpConfig.childEnv,
+          PATH: extendedPath,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+
+    // Catch spawn errors (e.g. ENOENT) to prevent crashing the provider runtime.
+    processHandle.on("error", (spawnError) => {
+      console.error(`[browser-local][claude] Spawn error: ${spawnError.message}`);
+      sessions.delete(sessionId);
+      emit("provider://error", {
+        sessionId,
+        error: spawnError.code === "ENOENT"
+          ? `Claude Code CLI not found at "${claudeBin}". Install it from https://claude.ai/download`
+          : `Failed to start Claude Code: ${spawnError.message}`,
+      });
+      emit("provider://session-status", {
+        sessionId,
+        status: "terminated",
+      });
+    });
+
+    const resolvedMode = claudeModeFromApprovalPolicy(approvalPolicy);
+    const session = createSessionRecord({
+      sessionId,
+      cwd,
+      processHandle,
+      timeoutSecs,
+      agentSessionId: remoteSessionId,
+      currentModeId: "default",
+      mcpConfigJson: mcpConfig.claudeMcpConfigJson,
+      spawnEnv: mcpConfig.childEnv,
+    });
+
+    sessions.set(sessionId, session);
+    attachProcessListeners(emit, sessions, session, exitPromises);
+
+    try {
+      const initResult = await sendControlRequest(
+        session,
+        {
+          subtype: "initialize",
+          hooks: null,
+        },
+        20_000,
+      );
+
+      session.availableModelRecords = normalizeModelRecords(initResult);
+      session.currentModelId =
+        inferCurrentModelId(
+          initResult?.model ?? null,
+          session.availableModelRecords,
+        ) ??
+        session.currentModelId;
+
+      // The launched session stays in its default permission flow until we
+      // explicitly switch modes over the control channel.
+      await sendControlRequest(
+        session,
+        { subtype: "set_permission_mode", mode: resolvedMode },
+        10_000,
+      );
+      session.currentModeId = resolvedMode;
+
+      if (resumeAgentSessionId) {
+        await replayClaudeHistoryBestEffort(
+          emit,
+          session,
+          cwd,
+          resumeAgentSessionId,
+        );
+      }
+
+      session.status = "ready";
+
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+
+      return {
+        id: session.id,
+        agentType: session.agentType,
+        cwd: session.cwd,
+        status: session.status,
+        createdAt: session.createdAt,
+        agentSessionId: session.agentSessionId,
+        timeoutSecs: session.timeoutSecs,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sessions.delete(sessionId);
+      killChildTree(processHandle);
+      emit("provider://error", {
+        sessionId,
+        error: isAuthError(message)
+          ? "Agent authentication required. Run the login flow and try again."
+          : message,
+      });
+      throw error;
+    }
+  }
+
+  async function sendPrompt({ sessionId, prompt, context }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    if (session.currentPrompt) {
+      throw new Error("Another prompt is already active for this session.");
+    }
+
+    const combinedPrompt = combinePrompt(prompt, context);
+    session.status = "prompting";
+    session.currentPromptHasChunks = false;
+    emit("provider://session-status", {
+      sessionId,
+      status: "prompting",
+      agentSessionId: session.agentSessionId,
+    });
+
+    const pendingPrompt = new Promise((resolvePromise, rejectPromise) => {
+      session.currentPrompt = {
+        resolve: resolvePromise,
+        reject: rejectPromise,
+      };
+    });
+
+    writeMessage(session, {
+      type: "user",
+      message: {
+        role: "user",
+        content: combinedPrompt,
+      },
+      session_id: session.agentSessionId,
+    });
+
+    return pendingPrompt;
+  }
+
+  async function cancelPrompt({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    if (!session.currentPrompt) {
+      return;
+    }
+
+    await sendControlRequest(
+      session,
+      {
+        subtype: "interrupt",
+      },
+      10_000,
+    ).catch(() => {
+      // Best-effort interrupt only.
+    });
+
+    session.status = "ready";
+    emit("provider://error", {
+      sessionId,
+      error: "Task cancelled",
+    });
+    emit("provider://session-status", buildSessionStatus(session, "ready"));
+    rejectCurrentPrompt(session, new Error("Task cancelled"));
+  }
+
+  async function terminateSession({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    sessions.delete(sessionId);
+    rejectPendingControlRequests(
+      session,
+      new Error("Session terminated before request completed."),
+    );
+    rejectCurrentPrompt(session, new Error("Session terminated."));
+    session.output.close();
+    killChildTree(session.process);
+    emit("provider://session-status", {
+      sessionId,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  }
+
+  async function listSessions() {
+    return Array.from(sessions.values()).map((session) => ({
+      id: session.id,
+      agentType: session.agentType,
+      cwd: session.cwd,
+      status: session.status,
+      createdAt: session.createdAt,
+      agentSessionId: session.agentSessionId,
+      timeoutSecs: session.timeoutSecs,
+    }));
+  }
+
+  async function listRemoteSessions({ cwd }) {
+    const index = await readSessionsIndex(cwd);
+    const entries = Array.isArray(index?.entries) ? index.entries : [];
+
+    return {
+      sessions: entries.map((entry) => ({
+        sessionId: entry.sessionId,
+        cwd: entry.projectPath ?? cwd,
+        title: entry.firstPrompt ?? null,
+        updatedAt: entry.modified ?? null,
+      })),
+      nextCursor: null,
+    };
+  }
+
+  async function setPermissionMode({ sessionId, mode }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    if (
+      mode !== "default" &&
+      mode !== "acceptEdits" &&
+      mode !== "plan" &&
+      mode !== "bypassPermissions"
+    ) {
+      throw new Error(`Unsupported Claude mode: ${mode}`);
+    }
+
+    await sendControlRequest(
+      session,
+      {
+        subtype: "set_permission_mode",
+        mode,
+      },
+      10_000,
+    );
+
+    session.currentModeId = mode;
+    emit("provider://session-status", buildSessionStatus(session));
+  }
+
+  async function respondToPermission({ sessionId, requestId, optionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    const pending = session.pendingPermissions.get(requestId);
+    if (!pending) {
+      throw new Error(`No pending permission request: ${requestId}`);
+    }
+
+    session.pendingPermissions.delete(requestId);
+    if (optionId === "allow_session") {
+      session.allowedTools.add(pending.toolName);
+    }
+
+    if (optionId === "deny" || optionId === "cancel") {
+      emitToolResult(
+        emit,
+        session,
+        pending.toolUseId,
+        optionId === "cancel" ? "Turn cancelled" : "Tool use denied",
+        true,
+      );
+    }
+
+    writeMessage(session, {
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: pending.controlRequestId,
+        response: buildPermissionResponse(optionId, pending.toolInput),
+      },
+    });
+  }
+
+  async function setModel({ sessionId, modelId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    const targetModel =
+      session.availableModelRecords.find((record) => record.modelId === modelId) ??
+      null;
+    if (!targetModel) {
+      throw new Error(`Unknown Claude model: ${modelId}`);
+    }
+
+    await sendControlRequest(
+      session,
+      {
+        subtype: "set_model",
+        model: modelId,
+      },
+      10_000,
+    );
+
+    session.currentModelId = targetModel.modelId;
+    emit("provider://session-status", buildSessionStatus(session));
+  }
+
+  async function setConfigOption() {
+    return null;
+  }
+
+  async function forkSession({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    const sourceAgentSessionId = session.agentSessionId;
+    if (!sourceAgentSessionId) {
+      throw new Error("Claude session does not have a resumable session id yet.");
+    }
+
+    const historyPath = await findSessionJsonlPath(session.cwd, sourceAgentSessionId);
+    if (!historyPath) {
+      throw new Error(`Claude session not found: ${sourceAgentSessionId}`);
+    }
+
+    const forkedAgentSessionId = randomUUID();
+    const tempLocalSessionId = randomUUID();
+    const claudeBin = resolveClaudeBinary();
+    const processHandle = spawn(
+      claudeBin,
+      buildClaudeArgs({
+        sessionId: forkedAgentSessionId,
+        resumeSessionId: sourceAgentSessionId,
+        forkSession: true,
+        preferredModel: session.currentModelId,
+        mcpConfigJson: session.mcpConfigJson,
+      }),
+      {
+        cwd: session.cwd,
+        env: {
+          ...process.env,
+          ...(session.spawnEnv ?? {}),
+          PATH: buildExtendedPath(),
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      },
+    );
+
+    // Catch spawn errors to prevent crashing the provider runtime.
+    processHandle.on("error", (spawnError) => {
+      console.error(`[browser-local][claude] Fork spawn error: ${spawnError.message}`);
+    });
+
+    const tempSession = createSessionRecord({
+      sessionId: tempLocalSessionId,
+      cwd: session.cwd,
+      processHandle,
+      timeoutSecs: session.timeoutSecs,
+      agentSessionId: forkedAgentSessionId,
+      currentModelId: session.currentModelId,
+      currentModeId: session.currentModeId,
+      mcpConfigJson: session.mcpConfigJson,
+      spawnEnv: session.spawnEnv,
+    });
+    const tempSessions = new Map([[tempSession.id, tempSession]]);
+    attachProcessListeners(silentEmit, tempSessions, tempSession, new Map());
+
+    try {
+      const initResult = await sendControlRequest(
+        tempSession,
+        {
+          subtype: "initialize",
+          hooks: null,
+        },
+        20_000,
+      );
+
+      tempSession.availableModelRecords = normalizeModelRecords(initResult);
+      tempSession.currentModelId =
+        inferCurrentModelId(
+          initResult?.model ?? null,
+          tempSession.availableModelRecords,
+        ) ?? tempSession.currentModelId;
+
+      if (!tempSession.agentSessionId) {
+        throw new Error("Claude fork did not return a resumable session id.");
+      }
+
+      return tempSession.agentSessionId;
+    } finally {
+      tempSessions.delete(tempSession.id);
+      rejectPendingControlRequests(
+        tempSession,
+        new Error("Fork helper session terminated."),
+      );
+      rejectCurrentPrompt(
+        tempSession,
+        new Error("Fork helper session terminated."),
+      );
+      tempSession.output.close();
+      killChildTree(processHandle);
+    }
+  }
+
+  return {
+    hasSession(sessionId) {
+      return sessions.has(sessionId);
+    },
+    spawnSession,
+    sendPrompt,
+    cancelPrompt,
+    terminateSession,
+    listSessions,
+    listRemoteSessions,
+    setPermissionMode,
+    respondToPermission,
+    setModel,
+    setConfigOption,
+    forkSession,
+  };
+}

--- a/runtime/bin/browser-local/dialogs.mjs
+++ b/runtime/bin/browser-local/dialogs.mjs
@@ -1,0 +1,132 @@
+// ABOUTME: Native folder/file dialog helpers for browser-local runtime.
+// ABOUTME: Uses platform CLI tools so the local browser mode stays dependency-light.
+
+import { execFile } from "node:child_process";
+import { platform } from "node:os";
+import { dirname } from "node:path";
+
+const os = platform();
+
+function exec(command, args) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { timeout: 60_000 }, (error, stdout) => {
+      if (error) {
+        if (error.code === 1 || error.killed) {
+          resolve("");
+          return;
+        }
+        reject(error);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+export async function openFolderDialog() {
+  if (os === "darwin") {
+    const result = await exec("osascript", [
+      "-e",
+      'POSIX path of (choose folder with prompt "Select Project Folder")',
+    ]);
+    return result || null;
+  }
+
+  if (os === "linux") {
+    const result = await exec("zenity", [
+      "--file-selection",
+      "--directory",
+      "--title=Select Project Folder",
+    ]);
+    return result || null;
+  }
+
+  if (os === "win32") {
+    const result = await exec("powershell", [
+      "-NoProfile",
+      "-Command",
+      "[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; $f = New-Object System.Windows.Forms.FolderBrowserDialog; if ($f.ShowDialog() -eq 'OK') { $f.SelectedPath }",
+    ]);
+    return result || null;
+  }
+
+  throw new Error(`Unsupported platform: ${os}`);
+}
+
+export async function openFileDialog() {
+  if (os === "darwin") {
+    const result = await exec("osascript", [
+      "-e",
+      'POSIX path of (choose file with prompt "Select File")',
+    ]);
+    return result || null;
+  }
+
+  if (os === "linux") {
+    const result = await exec("zenity", [
+      "--file-selection",
+      "--title=Select File",
+    ]);
+    return result || null;
+  }
+
+  if (os === "win32") {
+    const result = await exec("powershell", [
+      "-NoProfile",
+      "-Command",
+      "[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; $f = New-Object System.Windows.Forms.OpenFileDialog; if ($f.ShowDialog() -eq 'OK') { $f.FileName }",
+    ]);
+    return result || null;
+  }
+
+  throw new Error(`Unsupported platform: ${os}`);
+}
+
+export async function saveFileDialog({ defaultPath } = {}) {
+  if (os === "darwin") {
+    const script = defaultPath
+      ? `POSIX path of (choose file name with prompt "Save File" default name "${defaultPath}")`
+      : 'POSIX path of (choose file name with prompt "Save File")';
+    const result = await exec("osascript", ["-e", script]);
+    return result || null;
+  }
+
+  if (os === "linux") {
+    const args = ["--file-selection", "--save", "--title=Save File"];
+    if (defaultPath) {
+      args.push(`--filename=${defaultPath}`);
+    }
+    const result = await exec("zenity", args);
+    return result || null;
+  }
+
+  if (os === "win32") {
+    const result = await exec("powershell", [
+      "-NoProfile",
+      "-Command",
+      "[System.Reflection.Assembly]::LoadWithPartialName('System.Windows.Forms') | Out-Null; $f = New-Object System.Windows.Forms.SaveFileDialog; if ($f.ShowDialog() -eq 'OK') { $f.FileName }",
+    ]);
+    return result || null;
+  }
+
+  throw new Error(`Unsupported platform: ${os}`);
+}
+
+export async function revealInFileManager({ path }) {
+  if (os === "darwin") {
+    await exec("open", ["-R", path]);
+    return;
+  }
+
+  if (os === "linux") {
+    await exec("xdg-open", [dirname(path)]);
+    return;
+  }
+
+  if (os === "win32") {
+    await exec("explorer", [`/select,${path}`]);
+    return;
+  }
+
+  throw new Error(`Unsupported platform: ${os}`);
+}

--- a/runtime/bin/browser-local/events.mjs
+++ b/runtime/bin/browser-local/events.mjs
@@ -1,0 +1,37 @@
+// ABOUTME: Event bus for browser-local runtime notifications.
+// ABOUTME: Broadcasts JSON-RPC notifications to authenticated WebSocket clients.
+
+const authenticatedClients = new Set();
+
+function eventAliases(method) {
+  if (typeof method !== "string") {
+    return [];
+  }
+
+  return [method];
+}
+
+export function addClient(ws) {
+  authenticatedClients.add(ws);
+  ws.on("close", () => authenticatedClients.delete(ws));
+}
+
+export function removeClient(ws) {
+  authenticatedClients.delete(ws);
+}
+
+export function emit(method, params = null) {
+  for (const eventMethod of eventAliases(method)) {
+    const payload = JSON.stringify({
+      jsonrpc: "2.0",
+      method: eventMethod,
+      params,
+    });
+
+    for (const client of authenticatedClients) {
+      if (client.readyState === client.OPEN) {
+        client.send(payload);
+      }
+    }
+  }
+}

--- a/runtime/bin/browser-local/fs.mjs
+++ b/runtime/bin/browser-local/fs.mjs
@@ -1,0 +1,86 @@
+// ABOUTME: File system handlers for browser-local runtime.
+// ABOUTME: Powers local workspace browsing and editor reads/writes over JSON-RPC.
+
+import {
+  access,
+  mkdir,
+  readFile as fsReadFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile as fsWriteFile,
+} from "node:fs/promises";
+import { resolve } from "node:path";
+
+function resolvePath(inputPath) {
+  if (typeof inputPath !== "string" || inputPath.trim().length === 0) {
+    throw new Error("A valid path is required.");
+  }
+  return resolve(inputPath);
+}
+
+export async function listDirectory({ path }) {
+  const directoryPath = resolvePath(path);
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+
+  return entries
+    .map((entry) => ({
+      name: entry.name,
+      path: resolve(directoryPath, entry.name),
+      is_directory: entry.isDirectory(),
+    }))
+    .sort((left, right) => {
+      if (left.is_directory !== right.is_directory) {
+        return left.is_directory ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name);
+    });
+}
+
+export async function readFile({ path }) {
+  return fsReadFile(resolvePath(path), "utf8");
+}
+
+export async function readFileBase64({ path }) {
+  const content = await fsReadFile(resolvePath(path));
+  return Buffer.from(content).toString("base64");
+}
+
+export async function writeFile({ path, content }) {
+  await fsWriteFile(resolvePath(path), content ?? "", "utf8");
+}
+
+export async function pathExists({ path }) {
+  try {
+    await access(resolvePath(path));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isDirectory({ path }) {
+  try {
+    const info = await stat(resolvePath(path));
+    return info.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function createFile({ path, content }) {
+  await fsWriteFile(resolvePath(path), content ?? "", "utf8");
+}
+
+export async function createDirectory({ path }) {
+  await mkdir(resolvePath(path), { recursive: true });
+}
+
+export async function deletePath({ path }) {
+  await rm(resolvePath(path), { recursive: true, force: true });
+}
+
+export async function renamePath({ oldPath, newPath }) {
+  await rename(resolvePath(oldPath), resolvePath(newPath));
+}

--- a/runtime/bin/browser-local/mcp-config.mjs
+++ b/runtime/bin/browser-local/mcp-config.mjs
@@ -1,0 +1,162 @@
+// ABOUTME: Shared MCP configuration builder for direct provider runtimes.
+// ABOUTME: Normalizes Seren's MCP settings into provider-specific Claude/Codex formats.
+
+const SEREN_MCP_SERVER_NAME = "seren-mcp";
+const SEREN_MCP_API_KEY_ENV = "SEREN_API_KEY";
+const SEREN_MCP_GATEWAY_URL =
+  process.env.SEREN_MCP_GATEWAY_URL ?? "https://mcp.serendb.com/mcp";
+
+function trimToNull(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeLocalServer(server) {
+  if (!server || server.enabled === false || server.type !== "local") {
+    return null;
+  }
+
+  const name = trimToNull(server.name);
+  const command = trimToNull(server.command);
+  if (!name || !command) {
+    return null;
+  }
+
+  const args = Array.isArray(server.args)
+    ? server.args.filter((arg) => typeof arg === "string")
+    : [];
+  const envEntries = Object.entries(server.env ?? {}).filter(
+    ([key, value]) => typeof key === "string" && typeof value === "string",
+  );
+
+  return {
+    name,
+    type: "stdio",
+    command,
+    args,
+    env: Object.fromEntries(envEntries),
+  };
+}
+
+function createRemoteSerenServer(apiKey) {
+  if (!trimToNull(apiKey)) {
+    return null;
+  }
+
+  return {
+    name: SEREN_MCP_SERVER_NAME,
+    type: "http",
+    url: SEREN_MCP_GATEWAY_URL,
+    headers: {
+      Authorization: `Bearer \${${SEREN_MCP_API_KEY_ENV}}`,
+    },
+    bearerTokenEnvVar: SEREN_MCP_API_KEY_ENV,
+  };
+}
+
+function dedupeServers(servers) {
+  const deduped = new Map();
+  for (const server of servers) {
+    if (!server?.name) {
+      continue;
+    }
+    deduped.set(server.name, server);
+  }
+  return Array.from(deduped.values());
+}
+
+function encodeTomlValue(value) {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : JSON.stringify(String(value));
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => encodeTomlValue(item)).join(", ")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .map(([key, child]) => `${JSON.stringify(key)}=${encodeTomlValue(child)}`)
+      .join(", ")}}`;
+  }
+  return '""';
+}
+
+function buildClaudeMcpConfig(servers) {
+  if (servers.length === 0) {
+    return null;
+  }
+
+  const mcpServers = {};
+  for (const server of servers) {
+    if (server.type === "http") {
+      mcpServers[server.name] = {
+        type: "http",
+        url: server.url,
+        headers: server.headers ?? {},
+      };
+      continue;
+    }
+
+    mcpServers[server.name] = {
+      type: "stdio",
+      command: server.command,
+      args: server.args ?? [],
+      env: server.env ?? {},
+    };
+  }
+
+  return JSON.stringify({ mcpServers });
+}
+
+function buildCodexMcpOverride(servers) {
+  if (servers.length === 0) {
+    return null;
+  }
+
+  const mcpServers = {};
+  for (const server of servers) {
+    if (server.type === "http") {
+      mcpServers[server.name] = {
+        url: server.url,
+        bearer_token_env_var: server.bearerTokenEnvVar,
+      };
+      continue;
+    }
+
+    mcpServers[server.name] = {
+      command: server.command,
+      args: server.args ?? [],
+      ...(server.env && Object.keys(server.env).length > 0
+        ? { env: server.env }
+        : {}),
+    };
+  }
+
+  return `mcp_servers=${encodeTomlValue(mcpServers)}`;
+}
+
+export function buildProviderMcpConfig({ apiKey, mcpServers } = {}) {
+  const normalizedServers = dedupeServers([
+    createRemoteSerenServer(apiKey),
+    ...((Array.isArray(mcpServers) ? mcpServers : [])
+      .map((server) => normalizeLocalServer(server))
+      .filter(Boolean)),
+  ].filter(Boolean));
+
+  return {
+    childEnv:
+      trimToNull(apiKey) == null
+        ? {}
+        : { [SEREN_MCP_API_KEY_ENV]: trimToNull(apiKey) },
+    claudeMcpConfigJson: buildClaudeMcpConfig(normalizedServers),
+    codexMcpConfigOverride: buildCodexMcpOverride(normalizedServers),
+  };
+}

--- a/runtime/bin/browser-local/providers.mjs
+++ b/runtime/bin/browser-local/providers.mjs
@@ -1,0 +1,1409 @@
+// ABOUTME: Browser-local provider runtime for direct agent integrations.
+// ABOUTME: Runs Codex App Server directly over stdio while delegating install/login metadata to the agent registry.
+
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import readline from "node:readline";
+import { createBrowserLocalAgentRegistry } from "./agent-registry.mjs";
+import { createClaudeRuntime } from "./claude-runtime.mjs";
+import { buildProviderMcpConfig } from "./mcp-config.mjs";
+
+function isAuthError(message) {
+  const lower = String(message).toLowerCase();
+  return (
+    lower.includes("invalid api key") ||
+    lower.includes("authentication required") ||
+    lower.includes("auth required") ||
+    lower.includes("please run /login") ||
+    lower.includes("login required") ||
+    lower.includes("not logged in")
+  );
+}
+
+function killChildTree(child) {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+      return;
+    } catch {
+      // Fall through to direct kill.
+    }
+  }
+
+  try {
+    child.kill();
+  } catch {
+    // Ignore double-kill races during cleanup.
+  }
+}
+
+function mapDecision(optionId) {
+  switch (optionId) {
+    case "acceptForSession":
+    case "allow_session":
+      return "acceptForSession";
+    case "decline":
+    case "deny":
+    case "reject":
+      return "decline";
+    case "cancel":
+      return "cancel";
+    case "accept":
+    case "approve":
+    case "allow_once":
+    default:
+      return "accept";
+  }
+}
+
+function modeFromApprovalPolicy(approvalPolicy) {
+  switch (approvalPolicy) {
+    case "on-request":
+    case "untrusted":
+      return "ask";
+    default:
+      return "auto";
+  }
+}
+
+function sandboxFromMode(sandboxMode, networkEnabled) {
+  if (networkEnabled || sandboxMode === "danger-full-access") {
+    return "danger-full-access";
+  }
+  if (sandboxMode === "read-only") {
+    return "read-only";
+  }
+  return "workspace-write";
+}
+
+function codexApprovalPolicy(modeId) {
+  return modeId === "ask" ? "on-request" : "never";
+}
+
+function codexModes(session) {
+  return {
+    currentModeId: session?.currentModeId ?? "auto",
+    availableModes: [
+      {
+        modeId: "auto",
+        name: "Auto",
+        description: "Automatically approve safe operations",
+      },
+      {
+        modeId: "ask",
+        name: "Suggest",
+        description: "Ask for approval on each action",
+      },
+    ],
+  };
+}
+
+function buildInitializeParams() {
+  return {
+    clientInfo: {
+      name: "seren_browser_local",
+      title: "Seren Browser Local",
+      version: "0.1.0",
+    },
+    capabilities: {
+      experimentalApi: true,
+    },
+  };
+}
+
+function spawnCodexProcess(cwd, { apiKey, mcpServers } = {}) {
+  const mcpConfig = buildProviderMcpConfig({ apiKey, mcpServers });
+  const args = ["app-server"];
+  if (mcpConfig.codexMcpConfigOverride) {
+    args.push("-c", mcpConfig.codexMcpConfigOverride);
+  }
+
+  return spawn("codex", args, {
+    cwd,
+    env: {
+      ...process.env,
+      ...mcpConfig.childEnv,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+}
+
+function createCodexSessionRecord({
+  sessionId,
+  cwd,
+  processHandle,
+  timeoutSecs,
+  currentModeId,
+}) {
+  return {
+    id: sessionId,
+    agentType: "codex",
+    cwd,
+    status: "initializing",
+    createdAt: new Date().toISOString(),
+    process: processHandle,
+    output: readline.createInterface({ input: processHandle.stdout }),
+    pendingRequests: new Map(),
+    nextRequestId: 1,
+    pendingPermissions: new Map(),
+    toolOutputs: new Map(),
+    currentPrompt: null,
+    activeTurnId: null,
+    agentSessionId: undefined,
+    timeoutSecs: timeoutSecs ?? undefined,
+    codexVersion: null,
+    availableModelRecords: [],
+    currentModelId: null,
+    currentModeId,
+    reasoningEffort: "medium",
+    latestTurnUsage: undefined,
+  };
+}
+
+function normalizeModelRecords(result) {
+  const data = Array.isArray(result?.data) ? result.data : [];
+  return data
+    .filter((record) => record && record.hidden !== true)
+    .map((record) => ({
+      modelId: record.id ?? record.model,
+      name: record.displayName ?? record.id ?? record.model ?? "Unknown model",
+      description: record.description ?? undefined,
+      defaultReasoningEffort:
+        record.defaultReasoningEffort ??
+        record.default_reasoning_effort ??
+        "medium",
+      supportedReasoningEfforts: Array.isArray(record.supportedReasoningEfforts)
+        ? record.supportedReasoningEfforts
+            .map((effort) => ({
+              value: effort.reasoningEffort,
+              name: effort.reasoningEffort,
+              description: effort.description ?? undefined,
+            }))
+            .filter((effort) => typeof effort.value === "string")
+        : [],
+      isDefault: record.isDefault === true,
+    }))
+    .filter((record) => typeof record.modelId === "string");
+}
+
+function getSelectedModelRecord(session) {
+  return (
+    session.availableModelRecords.find(
+      (record) => record.modelId === session.currentModelId,
+    ) ??
+    session.availableModelRecords.find((record) => record.isDefault) ??
+    session.availableModelRecords[0] ??
+    null
+  );
+}
+
+function buildAvailableModels(session) {
+  return session.availableModelRecords.map((record) => ({
+    modelId: record.modelId,
+    name: record.name,
+    description: record.description,
+  }));
+}
+
+function buildConfigOptions(session) {
+  const modelRecord = getSelectedModelRecord(session);
+  const efforts =
+    modelRecord?.supportedReasoningEfforts?.length > 0
+      ? modelRecord.supportedReasoningEfforts
+      : [
+          { value: "low", name: "low" },
+          { value: "medium", name: "medium" },
+          { value: "high", name: "high" },
+          { value: "xhigh", name: "xhigh" },
+        ];
+
+  if (efforts.length === 0) {
+    return [];
+  }
+
+  const currentValue = efforts.some(
+    (option) => option.value === session.reasoningEffort,
+  )
+    ? session.reasoningEffort
+    : efforts[0]?.value ?? "medium";
+
+  session.reasoningEffort = currentValue;
+
+  return [
+    {
+      id: "reasoning_effort",
+      name: "Reasoning Effort",
+      description: "Controls how much reasoning Codex uses on future turns.",
+      type: "select",
+      currentValue,
+      options: efforts.map((option) => ({
+        value: option.value,
+        name: option.name,
+        description: option.description ?? null,
+      })),
+    },
+  ];
+}
+
+function buildSessionStatus(session, status = session.status) {
+  return {
+    sessionId: session.id,
+    status,
+    agentSessionId: session.agentSessionId,
+    agentInfo: {
+      name: "Codex App Server",
+      version: session.codexVersion ?? "unknown",
+    },
+    models: {
+      currentModelId: session.currentModelId,
+      availableModels: buildAvailableModels(session),
+    },
+    modes: codexModes(session),
+    configOptions: buildConfigOptions(session),
+  };
+}
+
+function replayChunkMeta(item) {
+  const messageId =
+    typeof item?.id === "string" && item.id.length > 0 ? item.id : undefined;
+  const rawTimestamp = item?.timestamp ?? item?.createdAt ?? item?.created_at;
+  const timestamp =
+    typeof rawTimestamp === "number"
+      ? rawTimestamp
+      : typeof rawTimestamp === "string" && rawTimestamp.length > 0
+        ? Date.parse(rawTimestamp)
+        : undefined;
+
+  return {
+    messageId,
+    timestamp:
+      typeof timestamp === "number" && Number.isFinite(timestamp)
+        ? timestamp
+        : undefined,
+  };
+}
+
+function replayUserMessage(emit, session, item) {
+  const content = Array.isArray(item?.content) ? item.content : [];
+  const { messageId, timestamp } = replayChunkMeta(item);
+
+  for (const block of content) {
+    if (block?.type !== "text" || typeof block?.text !== "string") {
+      continue;
+    }
+
+    emit("provider://user-message", {
+      sessionId: session.id,
+      text: block.text,
+      messageId,
+      timestamp,
+      replay: true,
+    });
+  }
+}
+
+function replayAgentMessage(emit, session, item) {
+  const { messageId, timestamp } = replayChunkMeta(item);
+  const text =
+    typeof item?.text === "string"
+      ? item.text
+      : Array.isArray(item?.content)
+        ? item.content
+            .map((part) =>
+              typeof part === "string"
+                ? part
+                : typeof part?.text === "string"
+                  ? part.text
+                  : "",
+            )
+            .filter(Boolean)
+            .join("")
+        : "";
+  if (!text) {
+    return;
+  }
+
+  emit("provider://message-chunk", {
+    sessionId: session.id,
+    text,
+    messageId,
+    timestamp,
+    replay: true,
+  });
+}
+
+function replayReasoning(emit, session, item) {
+  const { messageId, timestamp } = replayChunkMeta(item);
+  const text = Array.isArray(item?.content)
+    ? item.content
+        .map((part) =>
+          typeof part === "string"
+            ? part
+            : typeof part?.text === "string"
+              ? part.text
+              : "",
+        )
+        .filter(Boolean)
+        .join("")
+    : typeof item?.text === "string"
+      ? item.text
+      : "";
+  if (!text) {
+    return;
+  }
+
+  emit("provider://message-chunk", {
+    sessionId: session.id,
+    text,
+    isThought: true,
+    messageId,
+    timestamp,
+    replay: true,
+  });
+}
+
+function replayToolLikeItem(emit, session, item) {
+  if (!isToolLikeItem(item)) {
+    return;
+  }
+
+  emitToolCall(emit, session, item, item?.status ?? "completed");
+  emitToolResult(emit, session, item);
+}
+
+function replayThreadItems(emit, session, thread) {
+  const turns = Array.isArray(thread?.turns) ? thread.turns : [];
+  for (const turn of turns) {
+    const items = Array.isArray(turn?.items) ? turn.items : [];
+    for (const item of items) {
+      switch (item?.type) {
+        case "userMessage":
+          replayUserMessage(emit, session, item);
+          break;
+        case "agentMessage":
+          replayAgentMessage(emit, session, item);
+          break;
+        case "reasoning":
+          replayReasoning(emit, session, item);
+          break;
+        default:
+          replayToolLikeItem(emit, session, item);
+          break;
+      }
+    }
+  }
+
+  emit("provider://prompt-complete", {
+    sessionId: session.id,
+    stopReason: "HistoryReplay",
+    historyReplay: true,
+  });
+}
+
+function isToolLikeItem(item) {
+  const type = String(item?.type ?? "").toLowerCase();
+  return (
+    type.includes("command") ||
+    type.includes("filechange") ||
+    type.includes("tool") ||
+    type.includes("mcp") ||
+    type.includes("websearch")
+  );
+}
+
+function emitToolCall(emit, session, item, statusOverride) {
+  const type = String(item?.type ?? "").toLowerCase();
+  if (!isToolLikeItem(item)) {
+    return;
+  }
+
+  const toolCallId = String(item.id ?? randomUUID());
+  const title =
+    item.command ??
+    item.title ??
+    item.path ??
+    (type.includes("command")
+      ? "Command run"
+      : type.includes("filechange")
+        ? "File change"
+        : type.includes("websearch")
+          ? "Web search"
+          : "Tool call");
+
+  emit("provider://tool-call", {
+    sessionId: session.id,
+    toolCallId,
+    title,
+    kind: item.type ?? "tool",
+    status: statusOverride ?? item.status ?? "in_progress",
+    parameters: item,
+  });
+}
+
+function emitToolResult(emit, session, item) {
+  if (!isToolLikeItem(item)) {
+    return;
+  }
+  const toolCallId = String(item?.id ?? "");
+  if (!toolCallId) {
+    return;
+  }
+
+  const bufferedOutput = session.toolOutputs.get(toolCallId) ?? "";
+  const rawResult =
+    item.aggregatedOutput ??
+    item.formattedOutput ??
+    item.output ??
+    bufferedOutput;
+  const result =
+    typeof rawResult === "string" && rawResult.length === 0
+      ? undefined
+      : rawResult;
+
+  emit("provider://tool-result", {
+    sessionId: session.id,
+    toolCallId,
+    status: item.status ?? "completed",
+    result,
+    error:
+      item.error?.message ??
+      item.error ??
+      (item.exitCode && item.exitCode !== 0
+        ? `Command exited with code ${item.exitCode}`
+        : undefined),
+  });
+
+  session.toolOutputs.delete(toolCallId);
+}
+
+function normalizeTurnUsage(tokenUsage) {
+  const last = tokenUsage?.last ?? tokenUsage?.total ?? null;
+  if (!last) {
+    return undefined;
+  }
+
+  return {
+    usage: {
+      input_tokens: last.inputTokens,
+      output_tokens: last.outputTokens,
+    },
+  };
+}
+
+function buildApprovalToolCall(method, params) {
+  const item = params?.item ?? {};
+  if (method === "item/commandExecution/requestApproval") {
+    return {
+      name: "commandExecution",
+      title: item.command ?? params?.command ?? "Run command",
+      input: {
+        command: item.command ?? params?.command ?? null,
+        cwd: item.cwd ?? params?.cwd ?? null,
+      },
+    };
+  }
+  if (method === "item/fileRead/requestApproval") {
+    return {
+      name: "fileRead",
+      title: "Read file",
+      input: {
+        path: item.path ?? params?.path ?? null,
+      },
+    };
+  }
+  return {
+    name: "fileChange",
+    title: item.path ?? params?.path ?? "Change file",
+    input: {
+      path: item.path ?? params?.path ?? null,
+      oldText: item.oldText ?? item.old_text ?? null,
+      newText: item.newText ?? item.new_text ?? null,
+    },
+  };
+}
+
+function isRecoverableResumeError(message) {
+  const lower = String(message).toLowerCase();
+  return (
+    lower.includes("not found") ||
+    lower.includes("missing thread") ||
+    lower.includes("unknown thread") ||
+    lower.includes("does not exist") ||
+    lower.includes("no rollout") ||
+    lower.includes("timed out")
+  );
+}
+
+function sendRequest(session, method, params, timeoutMs = 30_000) {
+  const id = session.nextRequestId;
+  session.nextRequestId += 1;
+
+  const payload = {
+    jsonrpc: "2.0",
+    id,
+    method,
+    params,
+  };
+
+  return new Promise((resolvePromise, rejectPromise) => {
+    const timeout = setTimeout(() => {
+      session.pendingRequests.delete(String(id));
+      rejectPromise(new Error(`Timed out waiting for ${method}.`));
+    }, timeoutMs);
+
+    session.pendingRequests.set(String(id), {
+      method,
+      timeout,
+      resolve: resolvePromise,
+      reject: rejectPromise,
+    });
+
+    session.process.stdin.write(`${JSON.stringify(payload)}\n`);
+  });
+}
+
+function writeMessage(session, message) {
+  session.process.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+function rejectPendingRequests(session, error) {
+  for (const [key, pending] of session.pendingRequests) {
+    clearTimeout(pending.timeout);
+    pending.reject(error);
+    session.pendingRequests.delete(key);
+  }
+}
+
+function rejectCurrentPrompt(session, error) {
+  if (!session.currentPrompt) {
+    return;
+  }
+  const pending = session.currentPrompt;
+  session.currentPrompt = null;
+  session.activeTurnId = null;
+  pending.reject(error);
+}
+
+function resolveCurrentPrompt(session) {
+  if (!session.currentPrompt) {
+    return;
+  }
+  const pending = session.currentPrompt;
+  session.currentPrompt = null;
+  session.activeTurnId = null;
+  pending.resolve();
+}
+
+function handleResponse(session, payload) {
+  const pending = session.pendingRequests.get(String(payload.id));
+  if (!pending) {
+    return;
+  }
+
+  clearTimeout(pending.timeout);
+  session.pendingRequests.delete(String(payload.id));
+
+  if (payload.error?.message) {
+    pending.reject(new Error(`${pending.method} failed: ${payload.error.message}`));
+    return;
+  }
+
+  pending.resolve(payload.result);
+}
+
+function handleServerRequest(emit, session, payload) {
+  const method = payload.method;
+  const requestId = randomUUID();
+  const pendingPermission = {
+    requestId,
+    jsonRpcId: payload.id,
+    method,
+  };
+
+  if (session.currentModeId === "auto") {
+    writeMessage(session, {
+      jsonrpc: "2.0",
+      id: payload.id,
+      result: {
+        decision: "accept",
+      },
+    });
+    return;
+  }
+
+  session.pendingPermissions.set(requestId, pendingPermission);
+
+  emit("provider://permission-request", {
+    sessionId: session.id,
+    requestId,
+    toolCall: buildApprovalToolCall(method, payload.params ?? {}),
+    options: [
+      {
+        optionId: "accept",
+        label: "Approve once",
+        description: "Allow this action one time.",
+      },
+      {
+        optionId: "acceptForSession",
+        label: "Approve session",
+        description: "Allow similar actions for the rest of this session.",
+      },
+    ],
+  });
+}
+
+function handleNotification(emit, session, payload) {
+  const method = payload.method;
+  const params = payload.params ?? {};
+
+  switch (method) {
+    case "thread/started": {
+      const thread = params.thread ?? {};
+      const threadId = thread.id ?? params.threadId;
+      if (typeof threadId === "string") {
+        session.agentSessionId = threadId;
+      }
+      return;
+    }
+
+    case "turn/started": {
+      const turnId = params.turn?.id;
+      if (typeof turnId === "string") {
+        session.activeTurnId = turnId;
+      }
+      session.status = "prompting";
+      return;
+    }
+
+    case "item/started": {
+      const item = params.item ?? {};
+      emitToolCall(emit, session, item, "in_progress");
+      return;
+    }
+
+    case "item/agentMessage/delta":
+      emit("provider://message-chunk", {
+        sessionId: session.id,
+        text: params.delta ?? "",
+      });
+      return;
+
+    case "item/reasoning/textDelta":
+    case "item/reasoning/summaryTextDelta":
+      emit("provider://message-chunk", {
+        sessionId: session.id,
+        text: params.delta ?? "",
+        isThought: true,
+      });
+      return;
+
+    case "item/commandExecution/outputDelta":
+    case "item/fileChange/outputDelta": {
+      const toolCallId = String(params.itemId ?? "");
+      if (!toolCallId) {
+        return;
+      }
+      const chunk = String(params.delta ?? "");
+      session.toolOutputs.set(
+        toolCallId,
+        `${session.toolOutputs.get(toolCallId) ?? ""}${chunk}`,
+      );
+      return;
+    }
+
+    case "item/completed": {
+      const item = params.item ?? {};
+      emitToolResult(emit, session, item);
+      return;
+    }
+
+    case "turn/plan/updated": {
+      const rawEntries =
+        params.entries ??
+        params.plan?.entries ??
+        params.plan ??
+        [];
+
+      if (!Array.isArray(rawEntries)) {
+        return;
+      }
+
+      emit("provider://plan-update", {
+        sessionId: session.id,
+        entries: rawEntries.map((entry) => ({
+          content:
+            entry.content ??
+            entry.title ??
+            entry.text ??
+            entry.step ??
+            "Untitled step",
+          status:
+            entry.status ??
+            entry.state ??
+            (entry.completed === true ? "completed" : "pending"),
+        })),
+      });
+      return;
+    }
+
+    case "thread/tokenUsage/updated": {
+      session.latestTurnUsage = normalizeTurnUsage(params.tokenUsage);
+      return;
+    }
+
+    case "turn/completed": {
+      const turn = params.turn ?? {};
+      const completedTurnId = turn.id ?? params.turnId;
+
+      // Ignore stale turn/completed from a previously cancelled turn.
+      // After cancellation, a delayed completion can race with a new prompt
+      // and resolve/reject the wrong currentPrompt.
+      if (
+        typeof completedTurnId === "string" &&
+        typeof session.activeTurnId === "string" &&
+        completedTurnId !== session.activeTurnId
+      ) {
+        return;
+      }
+
+      session.status = turn.status === "failed" ? "error" : "ready";
+      session.activeTurnId = null;
+
+      if (turn.status === "failed") {
+        const message =
+          turn.error?.message ??
+          turn.error ??
+          "Codex turn failed.";
+        emit("provider://error", {
+          sessionId: session.id,
+          error: message,
+        });
+        rejectCurrentPrompt(session, new Error(message));
+        return;
+      }
+
+      emit("provider://prompt-complete", {
+        sessionId: session.id,
+        stopReason: turn.stopReason ?? "end_turn",
+        ...(session.latestTurnUsage ? { meta: session.latestTurnUsage } : {}),
+      });
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+      resolveCurrentPrompt(session);
+      return;
+    }
+
+    case "error": {
+      const message =
+        params.error?.message ??
+        params.message ??
+        "Codex App Server error.";
+      emit("provider://error", {
+        sessionId: session.id,
+        error: message,
+      });
+      rejectCurrentPrompt(session, new Error(message));
+      return;
+    }
+
+    default:
+      return;
+  }
+}
+
+function handleLine(emit, session, line) {
+  let payload;
+  try {
+    payload = JSON.parse(line);
+  } catch {
+    return;
+  }
+
+  if (payload.id != null && payload.method) {
+    handleServerRequest(emit, session, payload);
+    return;
+  }
+
+  if (payload.id != null) {
+    handleResponse(session, payload);
+    return;
+  }
+
+  if (payload.method) {
+    handleNotification(emit, session, payload);
+  }
+}
+
+function attachProcessListeners(emit, sessions, session) {
+  session.output.on("line", (line) => handleLine(emit, session, line));
+
+  session.process.stderr.on("data", (chunk) => {
+    const message = String(chunk).trim();
+    if (message.length > 0) {
+      console.log(`[browser-local][codex] ${message}`);
+    }
+  });
+
+  session.process.on("exit", () => {
+    const wasTracked = sessions.delete(session.id);
+    if (!wasTracked) {
+      return;
+    }
+
+    rejectPendingRequests(
+      session,
+      new Error("Codex App Server stopped before request completed."),
+    );
+
+    if (session.currentPrompt) {
+      rejectCurrentPrompt(
+        session,
+        new Error("Worker thread dropped while prompt was active."),
+      );
+      emit("provider://error", {
+        sessionId: session.id,
+        error: "Worker thread dropped while prompt was active.",
+      });
+    }
+
+    session.status = "terminated";
+    emit("provider://session-status", {
+      sessionId: session.id,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  });
+}
+
+export function createProviderHandlers({ emit }) {
+  const sessions = new Map();
+  const agentRegistry = createBrowserLocalAgentRegistry({ emit });
+  const claudeRuntime = createClaudeRuntime({ emit });
+
+  async function withTemporaryCodexSession(cwd, callback) {
+    const processHandle = spawnCodexProcess(cwd);
+    const session = createCodexSessionRecord({
+      sessionId: randomUUID(),
+      cwd,
+      processHandle,
+      currentModeId: "auto",
+    });
+    const tempSessions = new Map([[session.id, session]]);
+    attachProcessListeners(() => {}, tempSessions, session);
+
+    try {
+      await sendRequest(session, "initialize", buildInitializeParams(), 15_000);
+      writeMessage(session, {
+        jsonrpc: "2.0",
+        method: "initialized",
+      });
+      return await callback(session);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        isAuthError(message)
+          ? "Agent authentication required. Run the login flow and try again."
+          : message,
+      );
+    } finally {
+      tempSessions.delete(session.id);
+      try {
+        session.output.close();
+      } catch {
+        // Ignore duplicate-close races during cleanup.
+      }
+      killChildTree(processHandle);
+    }
+  }
+
+  async function spawnSession(params) {
+    const {
+      agentType,
+      cwd,
+      localSessionId,
+      resumeAgentSessionId,
+      apiKey,
+      mcpServers,
+      approvalPolicy,
+      sandboxMode,
+      networkEnabled,
+      timeoutSecs,
+    } = params;
+
+    if (agentType === "claude-code") {
+      return claudeRuntime.spawnSession(params);
+    }
+
+    if (agentType !== "codex") {
+      throw new Error(`Unsupported browser-local agent type: ${agentType}`);
+    }
+
+    const sessionId = localSessionId ?? randomUUID();
+    const resolvedMode = modeFromApprovalPolicy(approvalPolicy);
+    const resolvedSandbox = sandboxFromMode(sandboxMode, networkEnabled);
+    const processHandle = spawnCodexProcess(cwd, { apiKey, mcpServers });
+    const session = createCodexSessionRecord({
+      sessionId,
+      cwd,
+      processHandle,
+      timeoutSecs,
+      currentModeId: resolvedMode,
+    });
+
+    sessions.set(sessionId, session);
+    attachProcessListeners(emit, sessions, session);
+
+    try {
+      await sendRequest(session, "initialize", buildInitializeParams(), 15_000);
+      writeMessage(session, {
+        jsonrpc: "2.0",
+        method: "initialized",
+      });
+
+      let modelListResult = null;
+      try {
+        modelListResult = await sendRequest(session, "model/list", {}, 10_000);
+      } catch (error) {
+        console.warn("[browser-local] Codex model/list failed:", error);
+      }
+
+      session.availableModelRecords = normalizeModelRecords(modelListResult);
+
+      const threadParams = {
+        cwd,
+        approvalPolicy: codexApprovalPolicy(resolvedMode),
+        sandbox: resolvedSandbox,
+        experimentalRawEvents: false,
+      };
+
+      let threadResult;
+      let resumedExistingThread = false;
+      if (resumeAgentSessionId) {
+        try {
+          threadResult = await sendRequest(
+            session,
+            "thread/resume",
+            {
+              ...threadParams,
+              threadId: resumeAgentSessionId,
+            },
+            20_000,
+          );
+          resumedExistingThread = true;
+        } catch (error) {
+          if (!isRecoverableResumeError(error instanceof Error ? error.message : error)) {
+            throw error;
+          }
+          threadResult = await sendRequest(
+            session,
+            "thread/start",
+            threadParams,
+            20_000,
+          );
+        }
+      } else {
+        threadResult = await sendRequest(
+          session,
+          "thread/start",
+          threadParams,
+          20_000,
+        );
+      }
+
+      session.agentSessionId =
+        threadResult?.thread?.id ??
+        threadResult?.threadId ??
+        session.agentSessionId;
+      session.codexVersion = threadResult?.thread?.cliVersion ?? session.codexVersion;
+      session.currentModelId =
+        threadResult?.model ??
+        getSelectedModelRecord(session)?.modelId ??
+        session.availableModelRecords[0]?.modelId ??
+        null;
+      session.reasoningEffort =
+        threadResult?.reasoningEffort ??
+        getSelectedModelRecord(session)?.defaultReasoningEffort ??
+        "medium";
+
+      if (resumedExistingThread && session.agentSessionId) {
+        let replayThread = threadResult?.thread;
+        if (!Array.isArray(replayThread?.turns)) {
+          const threadRead = await sendRequest(
+            session,
+            "thread/read",
+            {
+              threadId: session.agentSessionId,
+              includeTurns: true,
+            },
+            20_000,
+          );
+          replayThread = threadRead?.thread ?? threadRead;
+        }
+
+        if (replayThread) {
+          replayThreadItems(emit, session, replayThread);
+        }
+      }
+
+      session.status = "ready";
+
+      emit("provider://session-status", buildSessionStatus(session, "ready"));
+
+      return {
+        id: session.id,
+        agentType: session.agentType,
+        cwd: session.cwd,
+        status: session.status,
+        createdAt: session.createdAt,
+        agentSessionId: session.agentSessionId,
+        timeoutSecs: session.timeoutSecs,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sessions.delete(sessionId);
+      killChildTree(processHandle);
+      emit("provider://error", {
+        sessionId,
+        error: isAuthError(message)
+          ? "Agent authentication required. Run the login flow and try again."
+          : message,
+      });
+      throw error;
+    }
+  }
+
+  async function sendPrompt({ sessionId, prompt, context }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.sendPrompt({ sessionId, prompt, context });
+    }
+    if (session.currentPrompt) {
+      throw new Error("Another prompt is already active for this session.");
+    }
+
+    const contextText = Array.isArray(context)
+      ? context
+          .map((entry) => entry?.text)
+          .filter((value) => typeof value === "string" && value.length > 0)
+          .join("\n\n")
+      : "";
+    const combinedPrompt = [contextText, prompt].filter(Boolean).join("\n\n");
+
+    session.status = "prompting";
+    session.latestTurnUsage = undefined;
+    emit("provider://session-status", {
+      sessionId,
+      status: "prompting",
+      agentSessionId: session.agentSessionId,
+    });
+
+    const pendingPrompt = new Promise((resolvePromise, rejectPromise) => {
+      session.currentPrompt = {
+        resolve: resolvePromise,
+        reject: rejectPromise,
+      };
+    });
+
+    try {
+      const response = await sendRequest(
+        session,
+        "turn/start",
+        {
+          threadId: session.agentSessionId,
+          input: [
+            {
+              type: "text",
+              text: combinedPrompt,
+              text_elements: [],
+            },
+          ],
+          ...(session.currentModelId ? { model: session.currentModelId } : {}),
+          ...(session.reasoningEffort
+            ? { effort: session.reasoningEffort }
+            : {}),
+        },
+        20_000,
+      );
+
+      const turnId = response?.turn?.id;
+      if (typeof turnId === "string") {
+        session.activeTurnId = turnId;
+      }
+
+      await pendingPrompt;
+    } catch (error) {
+      session.status = "ready";
+      rejectCurrentPrompt(
+        session,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      throw error;
+    }
+  }
+
+  async function cancelPrompt({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.cancelPrompt({ sessionId });
+    }
+    if (session.activeTurnId) {
+      // Capture and clear activeTurnId before sending interrupt so a stale
+      // turn/completed from this turn cannot match a subsequently started turn.
+      const interruptTurnId = session.activeTurnId;
+      session.activeTurnId = null;
+
+      await sendRequest(
+        session,
+        "turn/interrupt",
+        {
+          threadId: session.agentSessionId,
+          turnId: interruptTurnId,
+        },
+        10_000,
+      ).catch(() => {
+        // Best-effort interrupt only.
+      });
+    }
+
+    session.status = "ready";
+    emit("provider://error", {
+      sessionId,
+      error: "Task cancelled",
+    });
+    emit("provider://session-status", buildSessionStatus(session, "ready"));
+    rejectCurrentPrompt(session, new Error("Task cancelled"));
+  }
+
+  async function terminateSession({ sessionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.terminateSession({ sessionId });
+    }
+
+    sessions.delete(sessionId);
+    rejectPendingRequests(
+      session,
+      new Error("Session terminated before request completed."),
+    );
+    rejectCurrentPrompt(session, new Error("Session terminated."));
+    session.output.close();
+    killChildTree(session.process);
+    emit("provider://session-status", {
+      sessionId,
+      status: "terminated",
+      agentSessionId: session.agentSessionId,
+    });
+  }
+
+  async function listSessions() {
+    return [
+      ...Array.from(sessions.values()).map((session) => ({
+        id: session.id,
+        agentType: session.agentType,
+        cwd: session.cwd,
+        status: session.status,
+        createdAt: session.createdAt,
+        agentSessionId: session.agentSessionId,
+        timeoutSecs: session.timeoutSecs,
+      })),
+      ...(await claudeRuntime.listSessions()),
+    ];
+  }
+
+  async function setPermissionMode({ sessionId, mode }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.setPermissionMode({ sessionId, mode });
+    }
+
+    session.currentModeId = mode === "ask" ? "ask" : "auto";
+    emit("provider://session-status", buildSessionStatus(session));
+  }
+
+  async function respondToPermission({ sessionId, requestId, optionId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.respondToPermission({ sessionId, requestId, optionId });
+    }
+
+    const pending = session.pendingPermissions.get(requestId);
+    if (!pending) {
+      throw new Error(`No pending permission request: ${requestId}`);
+    }
+
+    session.pendingPermissions.delete(requestId);
+    writeMessage(session, {
+      jsonrpc: "2.0",
+      id: pending.jsonRpcId,
+      result: {
+        decision: mapDecision(optionId),
+      },
+    });
+  }
+
+  async function respondToDiffProposal() {
+    return null;
+  }
+
+  async function getAvailableAgents() {
+    return agentRegistry.getAvailableAgents();
+  }
+
+  async function checkAgentAvailable({ agentType }) {
+    return agentRegistry.checkAgentAvailable(agentType);
+  }
+
+  async function ensureAgentCli({ agentType }) {
+    return agentRegistry.ensureAgentCli(agentType);
+  }
+
+  async function launchLogin({ agentType }) {
+    agentRegistry.launchLogin(agentType);
+  }
+
+  async function listRemoteSessions({ agentType, cwd, cursor }) {
+    if (agentType === "claude-code") {
+      return claudeRuntime.listRemoteSessions({ cwd, cursor });
+    }
+
+    return withTemporaryCodexSession(cwd, async (session) => {
+      const raw = await sendRequest(
+        session,
+        "thread/list",
+        {
+          cursor: cursor ?? undefined,
+          limit: 25,
+          sortKey: "updated_at",
+          archived: false,
+        },
+        20_000,
+      );
+      const entries = Array.isArray(raw?.data) ? raw.data : [];
+
+      return {
+        sessions: entries
+          .filter((entry) => {
+            const entryCwd = entry?.cwd;
+            return typeof entryCwd === "string" && entryCwd === cwd;
+          })
+          .map((entry) => ({
+            sessionId: entry.id,
+            cwd: entry.cwd,
+            title:
+              (typeof entry.preview === "string" && entry.preview.length > 0
+                ? entry.preview
+                : null) ?? null,
+            updatedAt:
+              (typeof entry.updatedAt === "string" && entry.updatedAt.length > 0
+                ? entry.updatedAt
+                : typeof entry.updated_at === "string" &&
+                    entry.updated_at.length > 0
+                  ? entry.updated_at
+                  : null) ?? null,
+          }))
+          .filter(
+            (entry) =>
+              typeof entry.sessionId === "string" &&
+              entry.sessionId.length > 0 &&
+              typeof entry.cwd === "string" &&
+              entry.cwd.length > 0,
+          ),
+        nextCursor:
+          (typeof raw?.nextCursor === "string" && raw.nextCursor.length > 0
+            ? raw.nextCursor
+            : typeof raw?.next_cursor === "string" && raw.next_cursor.length > 0
+              ? raw.next_cursor
+              : null) ?? null,
+      };
+    });
+  }
+
+  async function nativeForkSession({ sessionId }) {
+    if (claudeRuntime.hasSession(sessionId)) {
+      return claudeRuntime.forkSession({ sessionId });
+    }
+
+    throw new Error(
+      "Native provider forking is only supported for Claude sessions.",
+    );
+  }
+
+  async function setSessionModel({ sessionId, modelId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.setModel({ sessionId, modelId });
+    }
+
+    const targetModel =
+      session.availableModelRecords.find((record) => record.modelId === modelId) ??
+      null;
+    if (!targetModel) {
+      throw new Error(`Unknown Codex model: ${modelId}`);
+    }
+
+    session.currentModelId = targetModel.modelId;
+    const supportsCurrentEffort = targetModel.supportedReasoningEfforts.some(
+      (option) => option.value === session.reasoningEffort,
+    );
+    if (!supportsCurrentEffort) {
+      session.reasoningEffort = targetModel.defaultReasoningEffort ?? "medium";
+    }
+
+    emit("provider://session-status", buildSessionStatus(session));
+    emit("provider://config-options-update", {
+      sessionId,
+      configOptions: buildConfigOptions(session),
+    });
+  }
+
+  async function setSessionMode({ sessionId, mode }) {
+    return setPermissionMode({ sessionId, mode });
+  }
+
+  async function updateSessionConfigOption({ sessionId, configId, valueId }) {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      return claudeRuntime.setConfigOption({ sessionId, configId, valueId });
+    }
+    if (configId !== "reasoning_effort") {
+      return null;
+    }
+
+    const configOption = buildConfigOptions(session)[0];
+    if (
+      !configOption ||
+      !configOption.options.some((option) => option.value === valueId)
+    ) {
+      throw new Error(`Unsupported reasoning effort: ${valueId}`);
+    }
+
+    session.reasoningEffort = valueId;
+    emit("provider://config-options-update", {
+      sessionId,
+      configOptions: buildConfigOptions(session),
+    });
+    return null;
+  }
+
+  return {
+    spawnSession,
+    sendPrompt,
+    cancelPrompt,
+    terminateSession,
+    listSessions,
+    setPermissionMode,
+    respondToPermission,
+    respondToDiffProposal,
+    getAvailableAgents,
+    checkAgentAvailable,
+    ensureAgentCli,
+    launchLogin,
+    listRemoteSessions,
+    nativeForkSession,
+    setSessionModel,
+    setSessionMode,
+    updateSessionConfigOption,
+  };
+}

--- a/runtime/bin/browser-local/rpc.mjs
+++ b/runtime/bin/browser-local/rpc.mjs
@@ -1,0 +1,74 @@
+// ABOUTME: Minimal JSON-RPC 2.0 router for the browser-local runtime.
+// ABOUTME: Dispatches WebSocket method calls to async handlers.
+
+const handlers = new Map();
+
+export function registerHandler(method, handler) {
+  handlers.set(method, handler);
+}
+
+export async function handleRpcMessage(raw) {
+  let request;
+  try {
+    request = JSON.parse(raw);
+  } catch {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32700, message: "Parse error" },
+      id: null,
+    });
+  }
+
+  const id = request.id ?? null;
+  const isNotification = request.id === undefined;
+
+  if (!request.method || typeof request.method !== "string") {
+    if (isNotification) {
+      return null;
+    }
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: -32600, message: "Invalid request" },
+      id,
+    });
+  }
+
+  const handler = handlers.get(request.method);
+  if (!handler) {
+    if (isNotification) {
+      return null;
+    }
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32601,
+        message: `Method not found: ${request.method}`,
+      },
+      id,
+    });
+  }
+
+  try {
+    const result = await handler(request.params ?? {});
+    if (isNotification) {
+      return null;
+    }
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      result,
+      id,
+    });
+  } catch (error) {
+    if (isNotification) {
+      return null;
+    }
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: error instanceof Error ? error.message : String(error),
+      },
+      id,
+    });
+  }
+}

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -16,7 +16,6 @@
     "seren",
     "serendb",
     "serendesktop",
-    "acp",
     "mcp",
     "ai-agent",
     "local-runtime",
@@ -41,7 +40,6 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.13.1",
     "better-sqlite3": "^12.6.2",
     "sqlite-vec": "0.1.7-alpha.2",
     "viem": "^2.45.1",

--- a/runtime/pnpm-lock.yaml
+++ b/runtime/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@agentclientprotocol/sdk':
-        specifier: ^0.13.1
-        version: 0.13.1(zod@4.3.6)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -50,11 +47,6 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
-
-  '@agentclientprotocol/sdk@0.13.1':
-    resolution: {integrity: sha512-6byvu+F/xc96GBkdAx4hq6/tB3vT63DSBO4i3gYCz8nuyZMerVFna2Gkhm8EHNpZX0J9DjUxzZCW+rnHXUg0FA==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -1004,10 +996,6 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
-  '@agentclientprotocol/sdk@0.13.1(zod@4.3.6)':
-    dependencies:
-      zod: 4.3.6
-
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
@@ -1789,4 +1777,5 @@ snapshots:
 
   ws@8.19.0: {}
 
-  zod@4.3.6: {}
+  zod@4.3.6:
+    optional: true

--- a/runtime/src/handlers/index.ts
+++ b/runtime/src/handlers/index.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Called once at server startup.
 
 import { registerHandler } from "../rpc.js";
+import { emit } from "../events.js";
 import { orchestrate, cancelOrchestration } from "../services/orchestrator.js";
-import * as acp from "./acp.js";
 import * as chat from "./chat.js";
 import * as dialogs from "./dialogs.js";
 import * as fs from "./fs.js";
@@ -15,7 +15,41 @@ import * as updater from "./updater.js";
 import * as skills from "./skills.js";
 import * as wallet from "./wallet.js";
 
-export function registerAllHandlers(): void {
+/**
+ * Dynamically load the browser-local provider handlers and register them.
+ * These replace the old ACP protocol with direct Claude Code / Codex CLI spawning.
+ */
+async function registerProviderHandlers(): Promise<void> {
+  const { fileURLToPath } = await import("node:url");
+  const { dirname, join } = await import("node:path");
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  // In dev: runtime/src/handlers/ → runtime/bin/browser-local/
+  // In dist: runtime/dist/ → runtime/bin/browser-local/
+  const providersPath = join(__dirname, "..", "bin", "browser-local", "providers.mjs");
+  const { createProviderHandlers } = await import(providersPath);
+
+  const providerHandlers = createProviderHandlers({ emit });
+
+  registerHandler("provider_spawn", providerHandlers.spawnSession);
+  registerHandler("provider_prompt", providerHandlers.sendPrompt);
+  registerHandler("provider_cancel", providerHandlers.cancelPrompt);
+  registerHandler("provider_terminate", providerHandlers.terminateSession);
+  registerHandler("provider_list_sessions", providerHandlers.listSessions);
+  registerHandler("provider_set_permission_mode", providerHandlers.setPermissionMode);
+  registerHandler("provider_respond_to_permission", providerHandlers.respondToPermission);
+  registerHandler("provider_respond_to_diff_proposal", providerHandlers.respondToDiffProposal);
+  registerHandler("provider_get_available_agents", providerHandlers.getAvailableAgents);
+  registerHandler("provider_check_agent_available", providerHandlers.checkAgentAvailable);
+  registerHandler("provider_ensure_agent_cli", providerHandlers.ensureAgentCli);
+  registerHandler("provider_launch_login", providerHandlers.launchLogin);
+  registerHandler("provider_list_remote_sessions", providerHandlers.listRemoteSessions);
+  registerHandler("provider_native_fork_session", providerHandlers.nativeForkSession);
+  registerHandler("provider_set_session_model", providerHandlers.setSessionModel);
+  registerHandler("provider_update_session_config_option", providerHandlers.updateSessionConfigOption);
+}
+
+export async function registerAllHandlers(): Promise<void> {
   // File system handlers
   registerHandler("list_directory", fs.listDirectory);
   registerHandler("read_file", fs.readFile);
@@ -34,52 +68,8 @@ export function registerAllHandlers(): void {
   registerHandler("save_file_dialog", dialogs.saveFileDialog);
   registerHandler("reveal_in_file_manager", dialogs.revealInFileManager);
 
-  // ACP agent handlers (acp_* names)
-  registerHandler("acp_spawn", acp.acpSpawn);
-  registerHandler("acp_prompt", acp.acpPrompt);
-  registerHandler("acp_cancel", acp.acpCancel);
-  registerHandler("acp_terminate", acp.acpTerminate);
-  registerHandler("acp_list_sessions", acp.acpListSessions);
-  registerHandler("acp_set_permission_mode", acp.acpSetPermissionMode);
-  registerHandler("acp_respond_to_permission", acp.acpRespondToPermission);
-  registerHandler("acp_respond_to_diff_proposal", acp.acpRespondToDiffProposal);
-  registerHandler("acp_get_available_agents", acp.acpGetAvailableAgents);
-  registerHandler("acp_check_agent_available", acp.acpCheckAgentAvailable);
-  registerHandler("acp_ensure_claude_cli", acp.acpEnsureClaudeCli);
-  registerHandler("acp_ensure_codex_cli", acp.acpEnsureCodexCli);
-  registerHandler("acp_ensure_agent_cli", acp.acpEnsureAgentCli);
-  registerHandler("acp_launch_login", acp.acpLaunchLogin);
-
-  // Provider aliases — providers.ts (ported from desktop) uses provider_* names.
-  // These map 1:1 to the acp_* handlers above.
-  registerHandler("provider_get_available_agents", acp.acpGetAvailableAgents);
-  registerHandler("provider_spawn", acp.acpSpawn);
-  registerHandler("provider_cancel", acp.acpCancel);
-  registerHandler("provider_terminate", acp.acpTerminate);
-  registerHandler("provider_list_sessions", acp.acpListSessions);
-  registerHandler("provider_set_permission_mode", acp.acpSetPermissionMode);
-  registerHandler("provider_respond_to_permission", acp.acpRespondToPermission);
-  registerHandler("provider_respond_to_diff_proposal", acp.acpRespondToDiffProposal);
-  registerHandler("provider_ensure_agent_cli", acp.acpEnsureAgentCli);
-  registerHandler("provider_check_agent_available", acp.acpCheckAgentAvailable);
-  registerHandler("provider_prompt", acp.acpPrompt);
-  registerHandler("provider_launch_login", acp.acpLaunchLogin);
-
-  // Provider commands with no ACP equivalent — stubs that return safe defaults
-  registerHandler("provider_native_fork_session", async (params: { sessionId: string }) => {
-    // Fork creates a new session from an existing one's context.
-    // Not yet implemented — return empty string to indicate no fork created.
-    return "";
-  });
-  registerHandler("provider_list_remote_sessions", async () => {
-    return { sessions: [], nextCursor: null };
-  });
-  registerHandler("provider_set_session_model", async () => {
-    return { ok: true };
-  });
-  registerHandler("provider_update_session_config_option", async () => {
-    return { ok: true };
-  });
+  // Agent provider handlers — direct CLI spawning (replaced ACP protocol)
+  await registerProviderHandlers();
 
   // OpenClaw messaging gateway handlers
   registerHandler("openclaw_start", openclaw.openclawStart);

--- a/runtime/src/server.ts
+++ b/runtime/src/server.ts
@@ -361,9 +361,8 @@ const dataDir = join(homedir(), ".seren-local");
 mkdirSync(dataDir, { recursive: true });
 initChatDb(join(dataDir, "conversations.db"));
 
-registerAllHandlers();
-
-httpServer.listen(PORT, HOST, () => {
+registerAllHandlers().then(() => {
+  httpServer.listen(PORT, HOST, () => {
   const url = `http://${HOST}:${PORT}`;
   const hasSpa = existsSync(join(PUBLIC_DIR, "index.html"));
 
@@ -383,6 +382,7 @@ httpServer.listen(PORT, HOST, () => {
     console.log("[Seren Local] No embedded SPA found (runtime/public/). Run build:embed to bundle the app.");
   }
   checkForUpdates();
+  });
 });
 
 export { httpServer, wss, HOST, PORT, AUTH_TOKEN };


### PR DESCRIPTION
## Summary

Replaces the dead ACP (Agent Client Protocol) with direct CLI spawning, matching desktop commit da143cee.

- Copied desktop `bin/browser-local/*.mjs` — 8 files including `providers.mjs` (session management, CLI detection, auto-install), `claude-runtime.mjs` (Claude Code process management), `agent-registry.mjs` (agent detection)
- `handlers/index.ts` dynamically imports `providers.mjs`, calls `createProviderHandlers({ emit })`, registers all 16 `provider_*` handlers
- Removed `@agentclientprotocol/sdk` dependency (saves install time + binary size)
- Runtime dist: 146KB to 126KB

Closes #49

## Test plan

- [x] Runtime build passes (126KB)
- [x] 70 runtime tests pass
- [x] No remaining `@agentclientprotocol` imports

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
