### PR TITLE
feat: recurring auto-update check + About Dialog version (#57)

### DIFF
--- a/e2e/updater.spec.ts
+++ b/e2e/updater.spec.ts
@@ -1,0 +1,44 @@
+// ABOUTME: E2E tests for auto-updater functionality.
+// ABOUTME: Verifies update check runs and About Dialog shows version.
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Auto-updater", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("text=New Agent", { timeout: 15_000 });
+  });
+
+  test("runtime version is displayed in health endpoint", async ({
+    request,
+  }) => {
+    const res = await request.get("/health");
+    expect(res.ok()).toBeTruthy();
+    const body = await res.json();
+    expect(body.version).toBeTruthy();
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  test("About Dialog shows version and Check for Updates button", async ({
+    page,
+  }) => {
+    // Trigger the About dialog via the hamburger menu or event
+    await page.evaluate(() =>
+      window.dispatchEvent(new Event("open-about")),
+    );
+    await page.waitForTimeout(500);
+
+    // Dialog should be visible with version info
+    const dialog = page.locator("text=Seren").first();
+    await expect(dialog).toBeVisible({ timeout: 3_000 });
+
+    // Version row should show a real version — may take a moment for the RPC
+    await expect(page.locator(".about-value").first()).not.toHaveText("loading...", { timeout: 10_000 });
+    const versionText = await page.locator(".about-value").first().textContent();
+    expect(versionText).toMatch(/\d+\.\d+\.\d+/);
+
+    // Check for Updates button should be present
+    const checkBtn = page.locator("text=Check for Updates");
+    await expect(checkBtn).toBeVisible();
+  });
+});

--- a/src/components/common/AboutDialog.css
+++ b/src/components/common/AboutDialog.css
@@ -97,3 +97,16 @@
 .about-btn-copy:hover {
   opacity: 0.9;
 }
+
+.about-check-result {
+  padding: 0 20px 8px;
+  font-size: 12px;
+}
+
+.about-check-result--available {
+  color: #3fb950;
+}
+
+.about-check-result--current {
+  color: var(--muted-foreground);
+}

--- a/src/components/common/AboutDialog.tsx
+++ b/src/components/common/AboutDialog.tsx
@@ -1,24 +1,18 @@
-// ABOUTME: About Seren dialog showing build information.
+// ABOUTME: About Seren dialog showing build information and update check.
 // ABOUTME: Triggered by custom DOM event "open-about".
 
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
+import { updaterStore } from "@/stores/updater.store";
 import "./AboutDialog.css";
-
-interface BuildInfo {
-  app_version: string;
-  build_type: string;
-  platform: string;
-}
 
 export function AboutDialog() {
   const [isOpen, setIsOpen] = createSignal(false);
   const [copied, setCopied] = createSignal(false);
+  const [checkResult, setCheckResult] = createSignal<string | null>(null);
 
-  const buildInfo: BuildInfo = {
-    app_version: import.meta.env.VITE_APP_VERSION ?? "0.1.0",
-    build_type: import.meta.env.DEV ? "development" : "production",
-    platform: "browser",
-  };
+  const buildType = import.meta.env.DEV ? "development" : "production";
+
+  const version = () => updaterStore.state.currentVersion || "loading...";
 
   onMount(() => {
     const handler = () => setIsOpen(true);
@@ -29,6 +23,7 @@ export function AboutDialog() {
   function close() {
     setIsOpen(false);
     setCopied(false);
+    setCheckResult(null);
   }
 
   function handleBackdropClick(e: MouseEvent) {
@@ -37,15 +32,25 @@ export function AboutDialog() {
 
   function copyInfo() {
     const text = [
-      `Version: ${buildInfo.app_version}`,
-      `Build Type: ${buildInfo.build_type}`,
-      `Platform: ${buildInfo.platform}`,
+      `Version: ${version()}`,
+      `Build Type: ${buildType}`,
+      `Platform: browser`,
     ].join("\n");
 
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
+  }
+
+  async function handleCheckForUpdates() {
+    setCheckResult(null);
+    await updaterStore.checkForUpdates();
+    if (updaterStore.state.status === "available") {
+      setCheckResult(`Update available: v${updaterStore.state.latestVersion}`);
+    } else {
+      setCheckResult("You are up to date.");
+    }
   }
 
   return (
@@ -56,13 +61,30 @@ export function AboutDialog() {
             <h2>Seren</h2>
           </div>
           <div class="about-content">
-            <Row label="Version" value={buildInfo.app_version} />
-            <Row label="Build Type" value={buildInfo.build_type} />
-            <Row label="Platform" value={buildInfo.platform} />
+            <Row label="Version" value={version()} />
+            <Row label="Build Type" value={buildType} />
+            <Row label="Platform" value="browser" />
+            <Show when={updaterStore.state.status === "available"}>
+              <Row label="Latest" value={`v${updaterStore.state.latestVersion}`} />
+            </Show>
           </div>
+          <Show when={checkResult()}>
+            <div
+              class={`about-check-result ${updaterStore.state.status === "available" ? "about-check-result--available" : "about-check-result--current"}`}
+            >
+              {checkResult()}
+            </div>
+          </Show>
           <div class="about-footer">
             <button class="about-btn-ok" onClick={close}>
               OK
+            </button>
+            <button
+              class="about-btn-copy"
+              onClick={handleCheckForUpdates}
+              disabled={updaterStore.state.status === "checking"}
+            >
+              {updaterStore.state.status === "checking" ? "Checking..." : "Check for Updates"}
             </button>
             <button class="about-btn-copy" onClick={copyInfo}>
               {copied() ? "Copied!" : "Copy"}

--- a/src/stores/updater.store.ts
+++ b/src/stores/updater.store.ts
@@ -1,10 +1,12 @@
 // ABOUTME: Manages update state by checking npm registry via runtime RPC.
-// ABOUTME: Provides one-click update that restarts the server with the new version.
+// ABOUTME: Checks on startup and every 15 minutes. Provides one-click update that restarts the server.
 
 import { createStore } from "solid-js/store";
 import { isRuntimeConnected, runtimeInvoke, onRuntimeEvent } from "@/lib/bridge";
 
 export type UpdateStatus = "idle" | "checking" | "available" | "installing" | "error";
+
+const UPDATE_CHECK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
 interface UpdaterState {
   status: UpdateStatus;
@@ -28,22 +30,52 @@ const [state, setState] = createStore<UpdaterState>({
   error: null,
 });
 
+let checkInterval: ReturnType<typeof setInterval> | null = null;
+
 export const updaterStore = {
   get state() {
     return state;
   },
 
-  /** Check for updates on startup. Defers until runtime is connected. */
+  /** Check for updates on startup and start recurring checks. Defers until runtime is connected. */
   async initUpdater(): Promise<void> {
+    // Fetch version immediately from /health (no auth needed)
+    this._fetchVersionFromHealth();
+
     if (!isRuntimeConnected()) {
-      // Runtime not ready yet — wait for connection, then check
       const unsub = onRuntimeEvent("runtime:connected", () => {
         unsub();
-        this._doCheck();
+        this._startChecking();
       });
       return;
     }
+    await this._startChecking();
+  },
+
+  /** Fetch version from /health endpoint (always available, no auth needed). */
+  async _fetchVersionFromHealth(): Promise<void> {
+    if (state.currentVersion) return;
+    try {
+      const res = await fetch("/health");
+      if (res.ok) {
+        const data = await res.json();
+        if (data.version) setState("currentVersion", data.version);
+      }
+    } catch { /* ignore */ }
+  },
+
+  /** @internal — initial check + start recurring interval. */
+  async _startChecking(): Promise<void> {
+    await this._fetchVersionFromHealth();
     await this._doCheck();
+
+    if (!checkInterval) {
+      checkInterval = setInterval(() => {
+        if (state.status !== "installing") {
+          this._doCheck();
+        }
+      }, UPDATE_CHECK_INTERVAL_MS);
+    }
   },
 
   /** Perform the actual update check via runtime RPC. */
@@ -54,15 +86,19 @@ export const updaterStore = {
       setState("currentVersion", info.currentVersion);
       setState("latestVersion", info.latestVersion);
       setState("status", info.updateAvailable ? "available" : "idle");
+      if (info.updateAvailable) {
+        setState("dismissed", false);
+      }
     } catch (err) {
       console.warn("[Updater] Check failed:", err);
       setState("status", "idle");
     }
   },
 
-  /** Re-check the registry (e.g. from settings panel). */
+  /** Re-check the registry (e.g. from About dialog). */
   async checkForUpdates(): Promise<void> {
-    await this.initUpdater();
+    setState("dismissed", false);
+    await this._doCheck();
   },
 
   /** Trigger the update: server will restart with new version. */


### PR DESCRIPTION
Adds 15-minute recurring npm registry check matching seren-desktop pattern. About Dialog now shows runtime version from /health endpoint and offers a Check for Updates button. Playwright E2E verified.

Closes #57

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com